### PR TITLE
[Refactor/#19] DayScheduleItem 상태 표시를 StatusBadge 컴포넌트로 교체

### DIFF
--- a/components/DayScheduleItem.tsx
+++ b/components/DayScheduleItem.tsx
@@ -4,6 +4,7 @@ import { useTheme } from '@/hooks/useTheme';
 import { Typography, BorderRadius, Elevation } from '@/constants/theme';
 import IcPin from '@/assets/icons/ic_pin.svg';
 import { CheckButton } from '@/components/ui/CheckButton';
+import { ScheduleStatusBadge } from '@/components/ui/ScheduleStatusBadge';
 
 type Status = 'upcoming' | 'completed';
 
@@ -21,10 +22,7 @@ export function DayScheduleItem({ title, startTime, endTime, location, memo, sta
   const { colors, scheme } = useTheme();
 
   const isCompleted = status === 'completed';
-
-  const badgeBg = isCompleted ? colors.successBg : colors.warningBg;
-  const badgeText = isCompleted ? colors.success : colors.warning;
-  const badgeLabel = isCompleted ? '완료' : '예정';
+  const badgeStatus = isCompleted ? 'completed' : 'draft';
 
   return (
     <View
@@ -39,9 +37,8 @@ export function DayScheduleItem({ title, startTime, endTime, location, memo, sta
         <Text style={[styles.time, { color: colors.textCaption }]}>
           {startTime} ~ {endTime}
         </Text>
-        {/* TODO: StatusBadge 컴포넌트 완성 후 아래 인라인 뱃지를 교체 */}
-        <View style={[styles.badge, { backgroundColor: badgeBg }]}>
-          <Text style={[styles.badgeText, { color: badgeText }]}>{badgeLabel}</Text>
+        <View style={styles.statusBadgeWrapper}>
+          <ScheduleStatusBadge status={badgeStatus} />
         </View>
         <View style={styles.spacer} />
         <CheckButton checked={isCompleted} onToggle={onToggle} />
@@ -87,15 +84,9 @@ const styles = StyleSheet.create({
   spacer: {
     flex: 1,
   },
-  badge: {
-    paddingVertical: 2,
-    paddingHorizontal: 8,
-    borderRadius: BorderRadius.full,
+  statusBadgeWrapper: {
+    alignSelf: 'center',
   },
-  badgeText: {
-    ...Typography['label'],
-  },
-
   title: {
     ...Typography['heading-md'],
   },
@@ -109,6 +100,6 @@ const styles = StyleSheet.create({
     flex: 1,
   },
   memo: {
-    ...Typography['heading-md'],
+    ...Typography['body-md'],
   },
 });


### PR DESCRIPTION
# 요약
<!--해당 PR에 대한 설명 혹은 이미지등을 넣어주세요. -->
DayScheduleItem 내부의 임시 상태 표시 UI를 제거하고, 공통 컴포넌트인 `components/ui/StatusBadge`를 적용합니다.
+ memo 부분 style을 `body-md` 으로 변경합니다.
# 연관 이슈 및 Close 할 이슈 작성
<!--이슈 번호를 적어주세요(예시: fix #123). -->
close #19

# Pull Request 체크리스트

- [x] 🔥 `DayScheduleItem`의 임시 상태 표시/Todo 코드 제거
- [x] 🔥 일정 상태값에 맞게 `StatusBadge` 컴포넌트 적
- [x] 🔥 Light/Dark 테마에서 배지 스타일이 디자인과 일치하는지 확인
- [x] 🔥 memo 부분 style을 `body-md` 으로 변경

## TODO

- [x] 최종 결과물을 확인했는가?
- [x] 의미 있는 커밋 메시지를 작성했는가?