### PR TITLE
[Feature/#29] React Query 캐싱 및 라우트 구조 정리

### DIFF
--- a/.claude/skills/new-screen/SKILL.md
+++ b/.claude/skills/new-screen/SKILL.md
@@ -1,49 +1,70 @@
 ---
 name: new-screen
-description: 새 화면(Screen) 생성 — app/ 라우트 진입점 + screens/ 실제 UI 파일 작성
-argument-hint: "라우트 경로 (예: (main)/schedule, (auth)/sign-up)"
-allowed-tools: Read, Write, Edit, Glob
+description: 새 화면(Screen) 생성. app/ 라우트 진입점과 screens/ 실제 UI 파일을 프로젝트 규칙에 맞게 작성한다.
+argument-hint: "라우트 경로 예: (main)/schedule, (auth)/sign-up, modal/place-detail"
+allowed-tools: Read, Write, Edit, Glob, Grep
 ---
 
-@docs/conventions.md 의 코딩 규칙을 준수한다.
+@docs/conventions.md 의 코딩 규칙을 우선 따른다.
 
 ## 사용법
 
 ```
-/new-screen (tabs)/schedule
+/new-screen (main)/home
 /new-screen (auth)/sign-up
-/new-screen modal/place-detail
 ```
 
 ## 입력
-사용자가 라우트 경로를 제공한다. (예: `(tabs)/schedule`, `modal/place-detail`)
+
+사용자가 Expo Router 기준 라우트 경로를 제공한다.
+
+예:
+- `(main)/home` -> `app/(main)/home.tsx`
+- `(auth)/sign-up` -> `app/(auth)/sign-up.tsx`
 
 ## 절차
 
-### 1. 디자인 문서 및 이미지 확인 (필수)
-아래 경로를 Glob으로 탐색하여 해당 화면의 디자인 문서를 찾는다.
+### 1. 디자인 문서 확인
+
+먼저 화면 이름을 기준으로 디자인 문서를 찾는다.
 
 ```
 docs/design/screens/{Name}/{Name}.md
-```
-
-- 문서가 **있으면** Read로 읽어 레이아웃, 컴포넌트 구성, SafeArea, 상태(Loading/Empty/Filled) 등 스펙을 파악한다.
-- 문서가 **없으면** 화면 이름과 역할로 구조를 추론한다.
-
-문서를 찾은 디렉토리에서 SVG 파일도 Glob으로 탐색한다.
-
-```
 docs/design/screens/{Name}/*.svg
 ```
 
-- SVG가 **있으면** Read로 모두 읽어 시각적 디자인을 파악한다 (레이아웃, 상태별 화면 구성, 간격 등).
+- 문서가 있으면 Read로 읽고 레이아웃, 컴포넌트 구성, 상태(Loading/Empty/Filled), SafeArea 요구사항을 반영한다.
+- SVG가 있으면 시각적 구조, 간격, 상태별 화면 구성을 확인한다.
+- 문서가 없으면 화면 이름과 역할에서 필요한 구조를 추론하되, 기존 화면 패턴을 우선 따른다.
 
-### 2. 라우트 그룹 확인
-- 요청한 경로의 라우트 그룹 `_layout.tsx`를 Read로 읽는다.
-- `(main)`에 추가하는 경우 BottomNavigation 업데이트가 필요하면 사용자에게 안내한다.
+### 2. 기존 구조 확인
 
-### 3. 라우트 진입점 파일 생성
-`app/{경로}.tsx` — 라우팅만 담당, UI 없음:
+작업 전 아래를 확인한다.
+
+- `app/` 라우트 구조
+- `screens/`의 기존 Screen 패턴
+- 필요한 경우 `components/`, `components/ui/`
+- 필요한 경우 `api/`, `constants/queryKeys.ts`
+- 라우트 그룹의 `_layout.tsx`
+
+`app/` 파일은 라우트 진입점만 담당하고, 실제 UI는 `screens/`에 둔다.
+
+라우트는 skill 문서에 이름만 적는다고 등록되지 않는다. Expo Router는 실제 `app/` 파일 구조를 기준으로 라우트를 만든다. 화면 이동 코드에서 `pathname: '/plan-list/[id]'` 같은 경로를 쓰려면 반드시 대응하는 실제 파일을 먼저 만든다.
+
+예:
+
+```txt
+app/(main)/plan-list.tsx                  -> /plan-list
+app/(main)/plan-list/[id]/index.tsx       -> /plan-list/[id]
+app/(main)/plan-list/[id]/edit.tsx        -> /plan-list/[id]/edit
+app/(main)/plan-list/[id]/logs/[logId].tsx -> /plan-list/[id]/logs/[logId]
+app/(main)/chat/index.tsx                 -> /chat
+app/(main)/chat/[chatId].tsx              -> /chat/[chatId]
+```
+
+### 3. 라우트 진입점 생성
+
+`app/{route}.tsx`는 UI를 직접 작성하지 않고 Screen만 렌더링한다.
 
 ```typescript
 import { {Name}Screen } from '@/screens/{Name}Screen';
@@ -53,43 +74,197 @@ export default function {Name}Route() {
 }
 ```
 
-params가 필요한 경우:
+params가 필요한 화면은 `useLocalSearchParams`로 받고 Screen에 props로 넘긴다.
+
 ```typescript
 import { useLocalSearchParams } from 'expo-router';
 import { {Name}Screen } from '@/screens/{Name}Screen';
 
 export default function {Name}Route() {
   const { id } = useLocalSearchParams<{ id: string }>();
-  return <{Name}Screen id={id} />;
+  return <{Name}Screen id={String(id)} />;
 }
 ```
 
-### 4. 화면 UI 파일 생성
-`screens/{Name}Screen.tsx` — 실제 화면 UI 담당:
+### 4. Screen UI 파일 생성
+
+`screens/{Name}Screen.tsx`에 실제 화면 UI를 작성한다.
+
+API 데이터가 필요한 화면은 `useEffect + setState`로 직접 fetch하지 말고 React Query를 사용한다.
 
 ```typescript
-import { useState, useEffect } from 'react';
-import { StyleSheet, View, Text, ActivityIndicator } from 'react-native';
+import { useEffect } from 'react';
+import { ActivityIndicator, StyleSheet, Text, View } from 'react-native';
+import { useQuery } from '@tanstack/react-query';
+import Toast from 'react-native-toast-message';
 import { useTheme } from '@/hooks/useTheme';
-import { Typography } from '@/constants/theme';
 import { useApi } from '@/hooks/useApi';
+import { Typography } from '@/constants/theme';
+import { getErrorMessage } from '@/utils/getErrorMessage';
+import { queryKeys, STALE_TIMES } from '@/constants/queryKeys';
+import { getChatRooms } from '@/api/chatRooms';
 
-type Props = {
-  // props 타입 정의
-};
-
-export function {Name}Screen({ ... }: Props) {
-  const [isLoading, setIsLoading] = useState(false);
+export function ExampleScreen() {
   const { colors } = useTheme();
   const { authRequest } = useApi();
 
-  // TODO: 초기 데이터 로드
+  const { data, isLoading, error } = useQuery({
+    queryKey: queryKeys.chatRooms.all,
+    queryFn: () => authRequest(getChatRooms),
+    staleTime: STALE_TIMES.chatRooms.all,
+  });
 
-  if (isLoading) return <ActivityIndicator />;
+  useEffect(() => {
+    if (!error) return;
+    Toast.show({ type: 'error', text1: getErrorMessage(error) });
+  }, [error]);
+
+  if (isLoading) {
+    return (
+      <View style={[styles.container, styles.center, { backgroundColor: colors.pageBg }]}>
+        <ActivityIndicator />
+      </View>
+    );
+  }
 
   return (
     <View style={[styles.container, { backgroundColor: colors.pageBg }]}>
-      <Text style={[styles.title, { color: colors.textTitle }]}>{Name} 화면</Text>
+      <Text style={[styles.title, { color: colors.textTitle }]}>Example</Text>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: { flex: 1, padding: 20 },
+  center: { alignItems: 'center', justifyContent: 'center' },
+  title: { ...Typography['heading-md'] },
+});
+```
+
+중요:
+- 위 예시의 `queryKeys.chatRooms.all`, `STALE_TIMES.chatRooms.all`, `getChatRooms`는 예시다.
+- 실제 도메인에 맞게 `queryKeys.{domain}.all`, `STALE_TIMES.{domain}.all`, 실제 API 함수명으로 치환한다.
+- API 함수명은 추측하지 말고 반드시 `api/{domain}.ts`의 export를 확인한다.
+- `queryKeys`에 없는 도메인이면 `constants/queryKeys.ts`에 먼저 추가한다.
+- `staleTime`은 React Query 필수 옵션은 아니지만, 서버 요청 빈도를 의도적으로 관리하기 위해 프로젝트에서는 조회 쿼리에 명시하는 것을 기본으로 한다.
+- 상세/메시지처럼 id별 캐시가 생기는 쿼리에는 `GC_TIMES`도 `@/constants/queryKeys`에서 import해서 `gcTime`을 명시한다.
+- API 에러는 화면에 고정 문구를 박기보다 `Toast.show({ type: 'error', text1: getErrorMessage(error) })`로 안내한다.
+
+### 5. queryKeys / STALE_TIMES 규칙
+
+목록 조회:
+
+```typescript
+queryKey: queryKeys.{domain}.all
+staleTime: STALE_TIMES.{domain}.all
+```
+
+상세 조회:
+
+```typescript
+queryKey: queryKeys.{domain}.detail(id)
+staleTime: STALE_TIMES.{domain}.detail
+```
+
+id 기반 상세 조회 또는 메시지 조회처럼 query key가 계속 늘어날 수 있는 데이터는 `GC_TIMES`도 함께 사용한다.
+
+```typescript
+import { queryKeys, STALE_TIMES, GC_TIMES } from '@/constants/queryKeys';
+
+useQuery({
+  queryKey: queryKeys.chatRooms.messages(roomId),
+  queryFn: () => authRequest((token) => getChatMessages(token, roomId)),
+  staleTime: STALE_TIMES.chatRooms.messages,
+  gcTime: GC_TIMES.chatRooms.messages,
+});
+```
+
+현재 주요 도메인:
+
+```typescript
+queryKeys.itineraries.all
+queryKeys.itineraries.detail(itineraryId)
+queryKeys.itineraries.logs(itineraryId)
+
+queryKeys.chatRooms.all
+queryKeys.chatRooms.detail(roomId)
+queryKeys.chatRooms.messages(roomId)
+
+queryKeys.reservations.all
+```
+
+`queryKeys`는 캐시 이름표이고, `STALE_TIMES`는 해당 캐시를 fresh로 볼 시간이다. 둘은 같은 역할이 아니며, 같은 데이터 단위에 맞춰 함께 사용한다.
+
+`GC_TIMES`는 inactive query를 메모리에 얼마나 보관할지 정하는 시간이다. 목록 쿼리는 캐시가 보통 1개라 필수로 두지 않고, `detail(id)`, `logs(id)`, `messages(roomId)`처럼 id별로 캐시가 쌓일 수 있는 쿼리에 우선 적용한다.
+
+### 6. 데이터 생성/수정/삭제 후 캐시 갱신 필수
+
+서버 데이터를 생성, 수정, 삭제하는 mutation을 추가할 때는 성공 후 반드시 관련 React Query 캐시를 갱신한다.
+
+기본 원칙:
+- 목록에 영향을 주면 `{domain}.all` invalidate
+- 상세에 영향을 주면 `{domain}.detail(id)` invalidate
+- 채팅 메시지 전송처럼 여러 도메인에 영향을 줄 수 있으면 관련 도메인을 함께 invalidate
+
+```typescript
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { queryKeys } from '@/constants/queryKeys';
+
+const queryClient = useQueryClient();
+
+const mutation = useMutation({
+  mutationFn: () => authRequest((token) => updateSomething(token, id, body)),
+  onSuccess: () => {
+    queryClient.invalidateQueries({ queryKey: queryKeys.itineraries.all });
+    queryClient.invalidateQueries({ queryKey: queryKeys.itineraries.detail(id) });
+  },
+});
+```
+
+SSE 채팅 메시지 전송은 `done` 이벤트를 받은 뒤 응답 필드에 따라 갱신한다.
+
+```typescript
+onDone: (done) => {
+  queryClient.invalidateQueries({ queryKey: queryKeys.chatRooms.messages(roomId) });
+  queryClient.invalidateQueries({ queryKey: queryKeys.chatRooms.all });
+
+  if (done.itinerary) {
+    queryClient.invalidateQueries({ queryKey: queryKeys.itineraries.all });
+    queryClient.invalidateQueries({
+      queryKey: queryKeys.itineraries.detail(done.itinerary.itineraryId),
+    });
+  }
+
+  if (done.change) {
+    queryClient.invalidateQueries({ queryKey: queryKeys.itineraries.all });
+    queryClient.invalidateQueries({
+      queryKey: queryKeys.itineraries.detail(done.change.itineraryId),
+    });
+  }
+
+  if (done.reservation || done.cancel) {
+    queryClient.invalidateQueries({ queryKey: queryKeys.reservations.all });
+  }
+};
+```
+
+캐시 갱신을 빼먹으면 화면이 staleTime 동안 오래된 데이터를 계속 보여줄 수 있다.
+
+### 7. API 데이터가 없는 화면
+
+정적 UI 또는 로컬 상태만 필요한 화면은 React Query를 쓰지 않는다.
+
+```typescript
+import { StyleSheet, Text, View } from 'react-native';
+import { useTheme } from '@/hooks/useTheme';
+import { Typography } from '@/constants/theme';
+
+export function {Name}Screen() {
+  const { colors } = useTheme();
+
+  return (
+    <View style={[styles.container, { backgroundColor: colors.pageBg }]}>
+      <Text style={[styles.title, { color: colors.textTitle }]}>{Name}</Text>
     </View>
   );
 }
@@ -100,13 +275,47 @@ const styles = StyleSheet.create({
 });
 ```
 
-### 5. 디자인 스펙 반영
-- 1단계에서 읽은 디자인 문서 스펙을 JSX와 StyleSheet에 반영한다.
-- 사용자가 추가 이미지를 제공한 경우 해당 디자인도 반영한다.
-- 색상 하드코딩 금지 — 반드시 `useTheme()` 훅 사용 (`colors.xxx` 형태로 인라인)
-- Typography는 `StyleSheet.create()` 안에 spread — 인라인에 직접 넣기 금지
-- SafeArea가 필요한 경우 `useSafeAreaInsets()` 사용, 하드코딩 금지
+### 8. SafeArea / BottomNavigation
 
-### 6. 완료 후 안내
-- 생성된 파일 경로 (라우트 + 스크린 2개)
-- 해당 화면에서 API 호출이 필요하면 `/new-api` 실행을 안내
+`(main)` 그룹 화면에서 `BottomNavigation` 뒤로 콘텐츠가 가려질 수 있으면 `useSafeAreaInsets`와 `BOTTOM_NAVIGATION`을 사용한다.
+
+```typescript
+import { ScrollView, StyleSheet } from 'react-native';
+import { useSafeAreaInsets } from 'react-native-safe-area-context';
+import { BOTTOM_NAVIGATION } from '@/constants/layout';
+
+const insets = useSafeAreaInsets();
+
+<ScrollView
+  contentContainerStyle={[
+    styles.content,
+    { paddingBottom: BOTTOM_NAVIGATION + insets.bottom + 16 },
+  ]}
+/>
+```
+
+### 9. 상대 시간 표시
+
+`몇 분 전`, `몇 시간 전` 같은 상대 시간 문자열은 서버 refetch 주기와 분리한다.
+
+- React Query `staleTime`은 서버 데이터를 언제 다시 가져올지 결정한다.
+- 상대 시간 표시는 로컬 timer로 1분마다 다시 계산한다.
+- 상대 시간 갱신 때문에 API를 더 자주 호출하지 않는다.
+
+### 10. 스타일 규칙
+
+- 색상은 `useTheme()`의 `colors.xxx`를 사용한다.
+- 하드코딩 색상은 피한다.
+- Typography는 `StyleSheet.create()` 안에서 spread한다.
+- inline style 객체는 동적 색상 등 필요한 경우에만 사용한다.
+- `TouchableOpacity`보다 `Pressable` + overlay 패턴을 우선 사용한다.
+- SafeArea 값은 하드코딩하지 않는다.
+
+### 11. 완료 보고
+
+완료 시 아래를 알려준다.
+
+- 생성/수정한 라우트 파일 경로
+- 생성/수정한 Screen 파일 경로
+- 추가한 query key 또는 stale time이 있으면 해당 내용
+- mutation/SSE로 인한 cache invalidate를 추가했다면 갱신 대상

--- a/app/(main)/chat/[chatId].tsx
+++ b/app/(main)/chat/[chatId].tsx
@@ -1,0 +1,8 @@
+import { useLocalSearchParams } from 'expo-router';
+import { ChatRoomScreen } from '@/screens/ChatRoomScreen';
+
+export default function ChatRoomRoute() {
+  const { chatId } = useLocalSearchParams<{ chatId: string }>();
+
+  return <ChatRoomScreen chatId={String(chatId)} />;
+}

--- a/app/(main)/chat/index.tsx
+++ b/app/(main)/chat/index.tsx
@@ -8,26 +8,25 @@ import { ChatRoomScreen } from '@/screens/ChatRoomScreen';
 export default function ChatRoute() {
   const { chatId, mode } = useLocalSearchParams<{ chatId?: string; mode?: 'new' }>();
   const isNew = mode === 'new';
-  const [recentChatId, setRecentChatId] = useState<string | null>(null);
   const [isLoading, setIsLoading] = useState(true);
-  // const { authRequest } = useApi(); // TODO: 활성화
 
   useEffect(() => {
     if (isNew || chatId) {
       setIsLoading(false);
       return;
     }
-    // TODO: API 연결 후 아래 주석 해제
-    // authRequest(getChatList).then(res => {
-    //   setRecentChatId(res.data[0]?.id ?? null);
-    //   setIsLoading(false);
-    // });
-    setIsLoading(false); // 임시
+
+    setIsLoading(false);
   }, [isNew, chatId]);
 
   if (isNew) return <NewChatScreen />;
-  if (chatId) return <ChatRoomScreen chatId={chatId} />;
-  if (isLoading) return <View style={{ flex: 1 }}><ActivityIndicator /></View>;
-  if (recentChatId) return <ChatRoomScreen chatId={recentChatId} />;
+  if (chatId) return <ChatRoomScreen chatId={String(chatId)} />;
+  if (isLoading) {
+    return (
+      <View style={{ flex: 1 }}>
+        <ActivityIndicator />
+      </View>
+    );
+  }
   return <NewChatScreen />;
 }

--- a/app/(main)/plan-list/[id]/edit.tsx
+++ b/app/(main)/plan-list/[id]/edit.tsx
@@ -1,0 +1,8 @@
+import { useLocalSearchParams } from 'expo-router';
+import { PlanListDetailEditScreen } from '@/screens/PlanListDetailEditScreen';
+
+export default function PlanListDetailEditRoute() {
+  const { id } = useLocalSearchParams<{ id: string }>();
+
+  return <PlanListDetailEditScreen id={String(id)} />;
+}

--- a/app/(main)/plan-list/[id]/index.tsx
+++ b/app/(main)/plan-list/[id]/index.tsx
@@ -1,0 +1,8 @@
+import { useLocalSearchParams } from 'expo-router';
+import { PlanListDetailScreen } from '@/screens/PlanListDetailScreen';
+
+export default function PlanListDetailRoute() {
+  const { id } = useLocalSearchParams<{ id: string }>();
+
+  return <PlanListDetailScreen id={String(id)} />;
+}

--- a/app/(main)/plan-list/[id]/logs/[logId].tsx
+++ b/app/(main)/plan-list/[id]/logs/[logId].tsx
@@ -1,0 +1,8 @@
+import { useLocalSearchParams } from 'expo-router';
+import { ChangeLogDetailScreen } from '@/screens/ChangeLogDetailScreen';
+
+export default function ChangeLogDetailRoute() {
+  const { id, logId } = useLocalSearchParams<{ id: string; logId: string }>();
+
+  return <ChangeLogDetailScreen itineraryId={String(id)} logId={String(logId)} />;
+}

--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -17,6 +17,9 @@ import { KeyboardProvider } from 'react-native-keyboard-controller';
 import { ClerkProvider, ClerkLoaded } from '@clerk/clerk-expo';
 import { tokenCache } from '@/utils/tokenCache';
 
+import { QueryClientProvider } from '@tanstack/react-query';
+import { queryClient } from '@/lib/queryClient';
+
 import { useColorScheme } from '@/hooks/use-color-scheme';
 import Toast from 'react-native-toast-message';
 import { SplashScreen } from '@/screens/SplashScreen';
@@ -67,34 +70,36 @@ export default function RootLayout() {
      * - publishableKey: Clerk 대시보드에서 발급받은 공개 키
      */
     <ClerkProvider tokenCache={tokenCache} publishableKey={publishableKey}>
-      <KeyboardProvider>
-      <ThemeProvider value={colorScheme === 'dark' ? DarkTheme : DefaultTheme}>
-        {(!fontsLoaded || splashVisible) ? (
-          <SplashScreen />
-        ) : (
-          /* ClerkLoaded: Clerk가 완전히 로드된 후에만 자식 컴포넌트를 렌더링
-           * 이를 통해 인증 상태가 준비되기 전의 깜빡임을 방지합니다. */
-          <ClerkLoaded>
-            <Stack>
-              {/* 인증 화면 (로그인, 회원가입 등) */}
-              <Stack.Screen name="(auth)/sign-in" options={{ headerShown: false }} />
-              {/* 메인 앱 화면 — BottomNavigation 포함 */}
-              <Stack.Screen name="(main)" options={{ headerShown: false }} />
-              {/* 초기 진입 라우팅 */}
-              <Stack.Screen name="index" options={{ headerShown: false }} />
-              <Stack.Screen name="oauth-native-callback" options={{ headerShown: false }} />
-              {/* 개발용 갤러리 허브 */}
-              <Stack.Screen name="dev_gallery" options={{ title: 'Dev Gallery' }} />
-              <Stack.Screen name="red_dev1" options={{ title: 'Red — Components 1' }} />
-              <Stack.Screen name="red_dev2" options={{ title: 'Red — Components 2' }} />
-              <Stack.Screen name="blue_dev1" options={{ title: 'Blue — Components 1' }} />
-            </Stack>
-            <StatusBar style="auto" />
-            <Toast />
-          </ClerkLoaded>
-        )}
-      </ThemeProvider>
-      </KeyboardProvider>
+      <QueryClientProvider client={queryClient}>
+        <KeyboardProvider>
+          <ThemeProvider value={colorScheme === 'dark' ? DarkTheme : DefaultTheme}>
+            {(!fontsLoaded || splashVisible) ? (
+              <SplashScreen />
+            ) : (
+              /* ClerkLoaded: Clerk가 완전히 로드된 후에만 자식 컴포넌트를 렌더링
+               * 이를 통해 인증 상태가 준비되기 전의 깜빡임을 방지합니다. */
+              <ClerkLoaded>
+                <Stack>
+                  {/* 인증 화면 (로그인, 회원가입 등) */}
+                  <Stack.Screen name="(auth)/sign-in" options={{ headerShown: false }} />
+                  {/* 메인 앱 화면 — BottomNavigation 포함 */}
+                  <Stack.Screen name="(main)" options={{ headerShown: false }} />
+                  {/* 초기 진입 라우팅 */}
+                  <Stack.Screen name="index" options={{ headerShown: false }} />
+                  <Stack.Screen name="oauth-native-callback" options={{ headerShown: false }} />
+                  {/* 개발용 갤러리 허브 */}
+                  <Stack.Screen name="dev_gallery" options={{ title: 'Dev Gallery' }} />
+                  <Stack.Screen name="red_dev1" options={{ title: 'Red — Components 1' }} />
+                  <Stack.Screen name="red_dev2" options={{ title: 'Red — Components 2' }} />
+                  <Stack.Screen name="blue_dev1" options={{ title: 'Blue — Components 1' }} />
+                </Stack>
+                <StatusBar style="auto" />
+                <Toast />
+              </ClerkLoaded>
+            )}
+          </ThemeProvider>
+        </KeyboardProvider>
+      </QueryClientProvider>
     </ClerkProvider>
   );
 }

--- a/constants/queryKeys.ts
+++ b/constants/queryKeys.ts
@@ -1,0 +1,47 @@
+export const queryKeys = {
+  itineraries: {
+    all: ['itineraries'] as const,
+    detail: (itineraryId: string) => ['itineraries', itineraryId] as const,
+    logs: (itineraryId: string) => ['itineraries', itineraryId, 'logs'] as const,
+  },
+
+  chatRooms: {
+    all: ['chatRooms'] as const,
+    detail: (roomId: string) => ['chatRooms', roomId] as const,
+    messages: (roomId: string) => ['chatRooms', roomId, 'messages'] as const,
+  },
+
+  reservations: {
+    all: ['reservations'] as const,
+  },
+} as const;
+
+export const STALE_TIMES = {
+  itineraries: {
+    all: 1000 * 60 * 10,
+    detail: 1000 * 60 * 5,
+    logs: 1000 * 60 * 2,
+  },
+
+  chatRooms: {
+    all: 1000 * 60 * 3,
+    detail: 1000 * 60 * 5,
+    messages: 1000 * 60 * 3,
+  },
+
+  reservations: {
+    all: 1000 * 60 * 10,
+  },
+} as const;
+
+export const GC_TIMES = {
+  itineraries: {
+    detail: 1000 * 60 * 5,
+    logs: 1000 * 60 * 3,
+  },
+
+  chatRooms: {
+    detail: 1000 * 60 * 5,
+    messages: 1000 * 60 * 3,
+  },
+} as const;

--- a/docs/conventions.md
+++ b/docs/conventions.md
@@ -1,29 +1,67 @@
 # Conventions — 프론트엔드 코딩 스타일
 
+## Route Reference
+
+Expo Router 라우트는 `app/` 파일 구조로 등록된다. 문서나 skill에 경로를 적는 것만으로는 라우트가 생성되지 않으므로, 화면 이동 코드에서 사용하는 경로는 반드시 실제 `app/` 파일이 있어야 한다.
+
+현재 주요 라우트:
+
+| 파일 | 실제 경로 | 역할 |
+|---|---|---|
+| `app/(main)/home.tsx` | `/home` | HomeScreen |
+| `app/(main)/chat/index.tsx` | `/chat` | 새 채팅 또는 기본 채팅 진입 |
+| `app/(main)/chat/[chatId].tsx` | `/chat/[chatId]` | 특정 채팅방 |
+| `app/(main)/plan.tsx` | `/plan` | PlanScreen |
+| `app/(main)/plan-list.tsx` | `/plan-list` | 여행 일정/예약 목록 |
+| `app/(main)/plan-list/[id]/index.tsx` | `/plan-list/[id]` | 여행 일정 상세 |
+| `app/(main)/plan-list/[id]/edit.tsx` | `/plan-list/[id]/edit` | 여행 일정 상세 편집 |
+| `app/(main)/plan-list/[id]/logs/[logId].tsx` | `/plan-list/[id]/logs/[logId]` | 변경 이력 상세 |
+| `app/(main)/setting.tsx` | `/setting` | 설정 |
+| `app/(auth)/sign-in.tsx` | `/sign-in` | 로그인 |
+
+동적 라우트 이동은 문자열 조합보다 typed pathname + params를 우선 사용한다.
+
+```tsx
+router.push({ pathname: '/plan-list/[id]', params: { id } });
+router.push({ pathname: '/plan-list/[id]/edit', params: { id } });
+router.push({ pathname: '/plan-list/[id]/logs/[logId]', params: { id, logId } });
+router.navigate({ pathname: '/chat/[chatId]', params: { chatId } });
+```
+
+`app/` 파일은 라우트 진입점만 담당하고, 실제 UI는 `screens/`에 둔다.
+
+---
+
 ## 1. 아키텍처
 
 ### 디렉토리 구조
 ```
 app/                         ← 라우팅만 담당 (UI 없음)
+├── _layout.tsx              ← 루트 레이아웃 (ClerkProvider, QueryClientProvider, Toast 등)
+├── index.tsx                ← 초기 진입 라우트
 ├── oauth-native-callback.tsx ← Android OAuth callback 수신 라우트
 ├── (auth)/
 │   └── sign-in.tsx          ← LoginScreen 렌더링, 로그인 상태면 /home 이동
-├── (main)/                  ← Stack + 커스텀 BottomNavigation 레이아웃
-│   ├── _layout.tsx          ← Stack navigator + BottomNavigation 컴포넌트
-│   ├── home.tsx             ← HomeScreen 진입점
-│   ├── chat.tsx             ← ChatScreen 진입점 (params로 분기)
-│   ├── plan.tsx             ← PlanScreen 진입점
-│   ├── plan-list.tsx        ← PlanListScreen 진입점
-│   ├── setting.tsx          ← SettingScreen 진입점
-│   └── plan-list/
-│       └── [id]/
-│           ├── index.tsx    ← PlanListDetailScreen 진입점
-│           └── edit.tsx     ← PlanListDetailEditScreen 진입점
-└── _layout.tsx              ← 루트 레이아웃 (Toast, ClerkProvider 등)
+└── (main)/                  ← Stack + 커스텀 BottomNavigation 레이아웃
+    ├── _layout.tsx          ← Stack navigator + BottomNavigation 컴포넌트
+    ├── home.tsx             ← HomeScreen 진입점
+    ├── plan.tsx             ← PlanScreen 진입점
+    ├── plan-list.tsx        ← PlanListScreen 진입점
+    ├── setting.tsx          ← SettingScreen 진입점
+    ├── chat/
+    │   ├── index.tsx        ← /chat
+    │   └── [chatId].tsx     ← /chat/[chatId]
+    └── plan-list/
+        └── [id]/
+            ├── index.tsx    ← /plan-list/[id]
+            ├── edit.tsx     ← /plan-list/[id]/edit
+            └── logs/
+                └── [logId].tsx ← /plan-list/[id]/logs/[logId]
 screens/                     ← 실제 화면 UI 담당
 ├── HomeScreen.tsx
 ├── NewChatScreen.tsx
 ├── ChatRoomScreen.tsx
+├── ChangeLogDetailScreen.tsx
 ├── PlanScreen.tsx
 ├── PlanListScreen.tsx
 ├── PlanListDetailScreen.tsx
@@ -38,7 +76,8 @@ components/
 └── {Name}.tsx      도메인 특화 컴포넌트 (ChatBubble, TravelPlanCard 등)
 hooks/              커스텀 훅
 utils/              순수 유틸리티 함수
-constants/          색상, 폰트 등 상수
+constants/          테마, 레이아웃, query key 등 상수
+lib/                앱 단위 인스턴스 (queryClient 등)
 ```
 
 ### 네비게이션 패턴
@@ -50,10 +89,11 @@ constants/          색상, 폰트 등 상수
 인증, 로그인/로그아웃, Android OAuth callback 흐름은 `docs/auth-routing.md`를 참고한다.
 
 ```
-파일 위치                    실제 경로
-app/(main)/home.tsx    →    /home
-app/(main)/chat.tsx    →    /chat
-app/(auth)/sign-in.tsx →    /sign-in
+파일 위치                         실제 경로
+app/(main)/home.tsx          →    /home
+app/(main)/chat/index.tsx    →    /chat
+app/(main)/chat/[chatId].tsx →    /chat/[chatId]
+app/(auth)/sign-in.tsx       →    /sign-in
 ```
 
 ```tsx
@@ -90,9 +130,9 @@ export default function MainLayout() {
 |---|---|---|
 | QuickMenu "AI와 채팅" | `/chat` | navigate |
 | QuickMenu "일정 보기" | `/plan` | navigate |
-| RecentTravelSection 카드 탭 | `/plan-list/:id` | push |
+| RecentTravelSection 카드 탭 | `/plan-list/[id]` | push |
 | RecentTravelSection "전체보기" | `/plan-list` | navigate |
-| RecentChatSection 카드 탭 | `/chat?chatId=:id` | navigate |
+| RecentChatSection 카드 탭 | `/chat` `{ chatId }` | navigate |
 | RecentChatSection "전체보기" | NavigationDrawer 오픈 | 컴포넌트 상태 |
 
 **ChatScreen 진입 분기**
@@ -116,7 +156,7 @@ router.navigate({
 });
 ```
 
-`chat.tsx` 내부에서 params로 분기:
+`chat/index.tsx` 내부에서 params로 분기:
 ```tsx
 const { chatId, mode } = useLocalSearchParams<{
   chatId?: string;
@@ -132,17 +172,17 @@ const isNew = mode === 'new';
 **PlanScreen**
 | 액션 | 목적지 | 방식 |
 |---|---|---|
-| NewTravelGenerateButton (Empty 상태) | `/chat?mode=new` | navigate |
+| NewTravelGenerateButton (Empty 상태) | `/chat` `{ mode: 'new' }` | navigate |
 
 **PlanListScreen**
 | 액션 | 목적지 | 방식 |
 |---|---|---|
-| TravelPlanCard 탭 | `/plan-list/:id` | push |
+| TravelPlanCard 탭 | `/plan-list/[id]` | push |
 
 **PlanListDetailScreen**
 | 액션 | 목적지 | 방식 |
 |---|---|---|
-| "편집" 버튼 | `/plan-list/:id/edit` | push |
+| "편집" 버튼 | `/plan-list/[id]/edit` | push |
 
 **PlanListDetailEditScreen**
 | 액션 | 목적지 | 방식 |
@@ -188,7 +228,7 @@ const res = await apiClient.get('/api/...', { headers: { Authorization: `Bearer 
 `app/` 파일은 라우팅 진입점만 담당. UI는 `screens/`에서 import. 단, params나 API 결과에 따른 분기 로직은 예외적으로 라우트 파일에 작성 허용.
 
 ```tsx
-// app/(main)/chat.tsx
+// app/(main)/chat/index.tsx
 import { NewChatScreen } from '@/screens/NewChatScreen';
 import { ChatRoomScreen } from '@/screens/ChatRoomScreen';
 import { PlanListScreen } from '@/screens/PlanListScreen';
@@ -208,30 +248,32 @@ export default function ChatRoute() {
 
 ### 화면(Screen) 컴포넌트 패턴
 ```typescript
-export default function {Name}Screen() {
-  // 1. 상태 선언
-  const [isLoading, setIsLoading] = useState(false);
-
-  // 2. 훅
+export function {Name}Screen() {
+  // 훅
   const { colors } = useTheme();
   const { authRequest } = useApi();
   const router = useRouter();
 
-  // 3. 이펙트
-  useEffect(() => {
-    // 초기 데이터 로드
-  }, []);
+  // API 데이터 조회 — useEffect + setState 직접 fetch 금지, React Query 사용
+  const { data, isLoading, error } = useQuery({
+    queryKey: queryKeys.{domain}.all,
+    queryFn: () => authRequest(get{Name}s),
+    staleTime: STALE_TIMES.{domain}.all,
+    // detail(id), logs(id), messages(roomId)처럼 id별 캐시가 쌓이는 쿼리는 gcTime: GC_TIMES.{domain}.{key} 도 추가
+  });
 
-  // 4. 핸들러 함수
+  useEffect(() => {
+    if (!error) return;
+    Toast.show({ type: 'error', text1: getErrorMessage(error) });
+  }, [error]);
+
+  // 핸들러 함수
   // 단순 버튼 클릭(onPress) — useCallback 불필요
   const handleAction = async () => {
-    setIsLoading(true);
     try {
-      // ...
+      // 서버 데이터 변경은 useMutation으로 처리
     } catch (e) {
       console.error(e);
-    } finally {
-      setIsLoading(false);
     }
   };
 
@@ -244,14 +286,14 @@ export default function {Name}Screen() {
     }
   }, [externalHookFn, router]);
 
-  // 5. 로딩/에러 분기
+  // 로딩/에러 분기
   if (isLoading) return <ActivityIndicator />;
 
-  // 6. JSX
+  // JSX
   return (
-    <SafeAreaView style={[styles.container, { backgroundColor: colors.pageBg }]}>
+    <View style={[styles.container, { backgroundColor: colors.pageBg }]}>
       {/* ... */}
-    </SafeAreaView>
+    </View>
   );
 }
 
@@ -271,7 +313,7 @@ export function SearchForm({ onSubmit }: { onSubmit: (query: string) => void }) 
 }
 
 // ✅ Screen — API 호출 담당
-export default function SearchScreen() {
+export function SearchScreen() {
   const handleSubmit = async (query: string) => {
     const result = await authRequest((token) => searchPlaces(token, query));
   };
@@ -524,11 +566,11 @@ const styles = StyleSheet.create({
 
 **Screen** — 콘텐츠가 바텀바에 가려지지 않도록 하단 여백 확보
 ```tsx
-// app/(main)/some-screen.tsx
+// screens/SomeScreen.tsx
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { BOTTOM_NAVIGATION } from '@/constants/layout';
 
-export default function SomeScreen() {
+export function SomeScreen() {
   const insets = useSafeAreaInsets();
 
   return (

--- a/lib/queryClient.ts
+++ b/lib/queryClient.ts
@@ -1,0 +1,9 @@
+import { QueryClient } from '@tanstack/react-query';
+
+export const queryClient = new QueryClient({
+  defaultOptions: {
+    queries: {
+      retry: 1,
+    },
+  },
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
         "@react-navigation/elements": "^2.6.3",
         "@react-navigation/native": "^7.1.8",
         "@react-navigation/stack": "^7.1.1",
+        "@tanstack/react-query": "^5.100.9",
         "axios": "^1.7.9",
         "expo": "~54.0.33",
         "expo-auth-session": "~5.4.0",
@@ -4529,6 +4530,32 @@
       "version": "5.87.4",
       "resolved": "https://registry.npmjs.org/@tanstack/query-core/-/query-core-5.87.4.tgz",
       "integrity": "sha512-uNsg6zMxraEPDVO2Bn+F3/ctHi+Zsk+MMpcN8h6P7ozqD088F6mFY5TfGM7zuyIrL7HKpDyu6QHfLWiDxh3cuw==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      }
+    },
+    "node_modules/@tanstack/react-query": {
+      "version": "5.100.9",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-query/-/react-query-5.100.9.tgz",
+      "integrity": "sha512-Oa44XkaI3kCNN6ME0KByU3xT3SEUNOMfZpHxL6+wFoTm+OeUFYHKdeYVe0aOXlRDm/f15sgLwEt2HDorIdW8+A==",
+      "license": "MIT",
+      "dependencies": {
+        "@tanstack/query-core": "5.100.9"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      },
+      "peerDependencies": {
+        "react": "^18 || ^19"
+      }
+    },
+    "node_modules/@tanstack/react-query/node_modules/@tanstack/query-core": {
+      "version": "5.100.9",
+      "resolved": "https://registry.npmjs.org/@tanstack/query-core/-/query-core-5.100.9.tgz",
+      "integrity": "sha512-SJSFw1S8+kQ0+knv/XGfrbocWoAlT7vDKsSImtLx3ZPQmEcR46hkDjLSvynSy25N8Ms4tIEini1FuBd5k7IscQ==",
       "license": "MIT",
       "funding": {
         "type": "github",

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "@react-navigation/elements": "^2.6.3",
     "@react-navigation/native": "^7.1.8",
     "@react-navigation/stack": "^7.1.1",
+    "@tanstack/react-query": "^5.100.9",
     "axios": "^1.7.9",
     "expo": "~54.0.33",
     "expo-auth-session": "~5.4.0",

--- a/screens/ChangeLogDetailScreen.tsx
+++ b/screens/ChangeLogDetailScreen.tsx
@@ -1,154 +1,20 @@
-import { useEffect, useMemo, useState } from 'react';
-import { ActivityIndicator, ScrollView, StyleSheet, Text, View } from 'react-native';
-import { useRouter } from 'expo-router';
-import { useQuery } from '@tanstack/react-query';
-import Toast from 'react-native-toast-message';
+import { View, Text, StyleSheet } from 'react-native';
 import { useTheme } from '@/hooks/useTheme';
-import { useApi } from '@/hooks/useApi';
-import { getItineraryLogs } from '@/api/itineraries';
-import { queryKeys, STALE_TIMES, GC_TIMES } from '@/constants/queryKeys';
-import { BOTTOM_NAVIGATION } from '@/constants/layout';
-import { Typography } from '@/constants/theme';
-import { getErrorMessage } from '@/utils/getErrorMessage';
-import { ItineraryOverviewCard2BeforeEdit } from '@/components/ItineraryOverviewCard2BeforeEdit';
-import { PlanDetailItem } from '@/components/PlanDetailItem';
 
 type Props = {
   itineraryId: string;
   logId: string;
 };
 
-type DayPlanItem = {
-  plan_name: string;
-  time: string;
-  place: string;
-  note: string;
-  status: string;
-  price?: number | null;
-};
-
-const formatDateRange = (startDate: string, endDate: string): string =>
-  `${startDate.replaceAll('-', '.')} ~ ${endDate.replaceAll('-', '.')}`;
-
-const splitTimeRange = (time: string) => {
-  const [startTime, endTime] = time.split('~').map((value) => value.trim());
-  return {
-    startTime: startTime || time,
-    endTime: endTime || '',
-  };
-};
-
 export function ChangeLogDetailScreen({ itineraryId, logId }: Props) {
-  const [selectedDay, setSelectedDay] = useState(1);
-
   const { colors } = useTheme();
-  const { authRequest } = useApi();
-  const router = useRouter();
-
-  const { data, isLoading, error } = useQuery({
-    queryKey: queryKeys.itineraries.logs(itineraryId),
-    queryFn: () => authRequest((token) => getItineraryLogs(token, itineraryId)),
-    staleTime: STALE_TIMES.itineraries.logs,
-    gcTime: GC_TIMES.itineraries.logs,
-  });
-
-  useEffect(() => {
-    if (!error) return;
-    Toast.show({ type: 'error', text1: getErrorMessage(error) });
-  }, [error]);
-
-  const selectedLog = useMemo(
-    () => data?.logs.find((log) => log.logId === logId),
-    [data?.logs, logId],
-  );
-
-  const dayDates = useMemo(
-    () => Object.keys(selectedLog?.dayPlans ?? {}).sort(),
-    [selectedLog?.dayPlans],
-  );
-
-  const selectedDate = dayDates[selectedDay - 1];
-  const items: DayPlanItem[] = selectedDate ? selectedLog?.dayPlans[selectedDate] ?? [] : [];
-  const changeLogDates = (data?.logs ?? []).map((log) => log.createdAt.slice(0, 10));
-
-  useEffect(() => {
-    if (dayDates.length > 0 && selectedDay > dayDates.length) {
-      setSelectedDay(1);
-    }
-  }, [dayDates.length, selectedDay]);
-
-  if (isLoading) {
-    return (
-      <View style={[styles.center, { backgroundColor: colors.pageBg }]}>
-        <ActivityIndicator />
-      </View>
-    );
-  }
-
-  if (!selectedLog) {
-    return (
-      <View style={[styles.center, { backgroundColor: colors.pageBg }]}>
-        <Text style={[styles.message, { color: colors.textSub }]}>변경 이력을 찾을 수 없습니다.</Text>
-      </View>
-    );
-  }
-
   return (
     <View style={[styles.container, { backgroundColor: colors.pageBg }]}>
-      <ItineraryOverviewCard2BeforeEdit
-        title={`${selectedLog.destination} 여행`}
-        date={formatDateRange(selectedLog.startDate, selectedLog.endDate)}
-        location={selectedLog.destination}
-        dayCount={Math.max(dayDates.length, selectedLog.totalDays)}
-        selectedDay={selectedDay}
-        onDayPress={setSelectedDay}
-        onBack={() => router.back()}
-        changeLogs={changeLogDates}
-        changeLogDate={selectedLog.createdAt.slice(0, 10)}
-      />
-
-      <ScrollView contentContainerStyle={styles.content} showsVerticalScrollIndicator={false}>
-        {items.length === 0 ? (
-          <Text style={[styles.message, { color: colors.textSub }]}>해당 날짜의 일정이 없습니다.</Text>
-        ) : (
-          items.map((item, index) => {
-            const { startTime, endTime } = splitTimeRange(item.time);
-            return (
-              <PlanDetailItem
-                key={`${selectedDate}-${index}`}
-                title={item.plan_name}
-                startTime={startTime}
-                endTime={endTime}
-                memo={item.note}
-                location={item.place}
-                price={item.price ?? undefined}
-                showConnector={index < items.length - 1}
-                defaultOpen={index === 0}
-              />
-            );
-          })
-        )}
-      </ScrollView>
+      <Text>ChangeLogDetailScreen {itineraryId} {logId}</Text>
     </View>
   );
 }
 
 const styles = StyleSheet.create({
-  container: {
-    flex: 1,
-  },
-  center: {
-    flex: 1,
-    alignItems: 'center',
-    justifyContent: 'center',
-  },
-  content: {
-    gap: 12,
-    padding: 20,
-    paddingBottom: BOTTOM_NAVIGATION + 24,
-  },
-  message: {
-    ...Typography['body-md'],
-    textAlign: 'center',
-  },
+  container: { flex: 1 },
 });

--- a/screens/ChangeLogDetailScreen.tsx
+++ b/screens/ChangeLogDetailScreen.tsx
@@ -1,0 +1,154 @@
+import { useEffect, useMemo, useState } from 'react';
+import { ActivityIndicator, ScrollView, StyleSheet, Text, View } from 'react-native';
+import { useRouter } from 'expo-router';
+import { useQuery } from '@tanstack/react-query';
+import Toast from 'react-native-toast-message';
+import { useTheme } from '@/hooks/useTheme';
+import { useApi } from '@/hooks/useApi';
+import { getItineraryLogs } from '@/api/itineraries';
+import { queryKeys, STALE_TIMES, GC_TIMES } from '@/constants/queryKeys';
+import { BOTTOM_NAVIGATION } from '@/constants/layout';
+import { Typography } from '@/constants/theme';
+import { getErrorMessage } from '@/utils/getErrorMessage';
+import { ItineraryOverviewCard2BeforeEdit } from '@/components/ItineraryOverviewCard2BeforeEdit';
+import { PlanDetailItem } from '@/components/PlanDetailItem';
+
+type Props = {
+  itineraryId: string;
+  logId: string;
+};
+
+type DayPlanItem = {
+  plan_name: string;
+  time: string;
+  place: string;
+  note: string;
+  status: string;
+  price?: number | null;
+};
+
+const formatDateRange = (startDate: string, endDate: string): string =>
+  `${startDate.replaceAll('-', '.')} ~ ${endDate.replaceAll('-', '.')}`;
+
+const splitTimeRange = (time: string) => {
+  const [startTime, endTime] = time.split('~').map((value) => value.trim());
+  return {
+    startTime: startTime || time,
+    endTime: endTime || '',
+  };
+};
+
+export function ChangeLogDetailScreen({ itineraryId, logId }: Props) {
+  const [selectedDay, setSelectedDay] = useState(1);
+
+  const { colors } = useTheme();
+  const { authRequest } = useApi();
+  const router = useRouter();
+
+  const { data, isLoading, error } = useQuery({
+    queryKey: queryKeys.itineraries.logs(itineraryId),
+    queryFn: () => authRequest((token) => getItineraryLogs(token, itineraryId)),
+    staleTime: STALE_TIMES.itineraries.logs,
+    gcTime: GC_TIMES.itineraries.logs,
+  });
+
+  useEffect(() => {
+    if (!error) return;
+    Toast.show({ type: 'error', text1: getErrorMessage(error) });
+  }, [error]);
+
+  const selectedLog = useMemo(
+    () => data?.logs.find((log) => log.logId === logId),
+    [data?.logs, logId],
+  );
+
+  const dayDates = useMemo(
+    () => Object.keys(selectedLog?.dayPlans ?? {}).sort(),
+    [selectedLog?.dayPlans],
+  );
+
+  const selectedDate = dayDates[selectedDay - 1];
+  const items: DayPlanItem[] = selectedDate ? selectedLog?.dayPlans[selectedDate] ?? [] : [];
+  const changeLogDates = (data?.logs ?? []).map((log) => log.createdAt.slice(0, 10));
+
+  useEffect(() => {
+    if (dayDates.length > 0 && selectedDay > dayDates.length) {
+      setSelectedDay(1);
+    }
+  }, [dayDates.length, selectedDay]);
+
+  if (isLoading) {
+    return (
+      <View style={[styles.center, { backgroundColor: colors.pageBg }]}>
+        <ActivityIndicator />
+      </View>
+    );
+  }
+
+  if (!selectedLog) {
+    return (
+      <View style={[styles.center, { backgroundColor: colors.pageBg }]}>
+        <Text style={[styles.message, { color: colors.textSub }]}>변경 이력을 찾을 수 없습니다.</Text>
+      </View>
+    );
+  }
+
+  return (
+    <View style={[styles.container, { backgroundColor: colors.pageBg }]}>
+      <ItineraryOverviewCard2BeforeEdit
+        title={`${selectedLog.destination} 여행`}
+        date={formatDateRange(selectedLog.startDate, selectedLog.endDate)}
+        location={selectedLog.destination}
+        dayCount={Math.max(dayDates.length, selectedLog.totalDays)}
+        selectedDay={selectedDay}
+        onDayPress={setSelectedDay}
+        onBack={() => router.back()}
+        changeLogs={changeLogDates}
+        changeLogDate={selectedLog.createdAt.slice(0, 10)}
+      />
+
+      <ScrollView contentContainerStyle={styles.content} showsVerticalScrollIndicator={false}>
+        {items.length === 0 ? (
+          <Text style={[styles.message, { color: colors.textSub }]}>해당 날짜의 일정이 없습니다.</Text>
+        ) : (
+          items.map((item, index) => {
+            const { startTime, endTime } = splitTimeRange(item.time);
+            return (
+              <PlanDetailItem
+                key={`${selectedDate}-${index}`}
+                title={item.plan_name}
+                startTime={startTime}
+                endTime={endTime}
+                memo={item.note}
+                location={item.place}
+                price={item.price ?? undefined}
+                showConnector={index < items.length - 1}
+                defaultOpen={index === 0}
+              />
+            );
+          })
+        )}
+      </ScrollView>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+  },
+  center: {
+    flex: 1,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  content: {
+    gap: 12,
+    padding: 20,
+    paddingBottom: BOTTOM_NAVIGATION + 24,
+  },
+  message: {
+    ...Typography['body-md'],
+    textAlign: 'center',
+  },
+});


### PR DESCRIPTION
# 요약
화면에서 사용할 데이터 캐싱 구조를 React Query 기반으로 정리합니다.
`QueryClientProvider`, `queryKeys`, `staleTime/gcTime` 상수를 추가하여 일정, 채팅방, 예약 데이터의 조회 캐시를 관리합니다. 또한 Expo Router의 실제 파일 기반 라우트 구조에 맞춰 채팅방 상세, 일정 상세, 일정 수정, 변경 이력 상세 라우트를 정리하고, 해당 구조가 new-screen skill과 conventions 문서에 반영되도록 업데이트합니다.

# 연관 이슈 및 Close 할 이슈 작성
close #29

# Pull Request 체크리스트

- [x] 🔥 React Query 셋업 추가
- [x] 🔥 일정/채팅/예약 queryKeys, staleTime, gcTime 상수 정리
- [x] 🔥 채팅 및 일정 상세 라우트 구조 정리
- [x] 🔥  `/chat`, `/chat/[chatId]`, `/plan-list/[id]`, `/plan-list/[id]/edit`, `/plan-list/[id]/logs/[logId]` 라우트 반영
- [x] 🔥 new-screen skill에 캐싱 및 실제 route 파일 예시 추가
- [x] 🔥 conventions 문서에 React Query 패턴, 라우트 컨벤션, 캐시 invalidate 기준 반영

# 참고사항
- 서버 부하나 데이터 최신성 요구에 따라 `STALE_TIMES`를 조정할 수 있습니다.
- id 기반 상세/메시지 캐시는 메모리 사용량을 보면서 `GC_TIMES`를 조정합니다.

## TODO

- [x] 최종 결과물을 확인했는가?
- [x] 의미 있는 커밋 메시지를 작성했는가?