### PR TITLE
[Feature, Refactor, Chore/#39] TripInfo 다구간 여행지 적용 및 Chatrooms 응답 상태 유지 개선

### DIFF
--- a/api/chatMessages.ts
+++ b/api/chatMessages.ts
@@ -88,6 +88,17 @@ export type ChatMessageActionResult =
   | { type: 'reservation'; data: DoneReservation }
   | { type: 'cancel'; data: DoneCancel };
 
+export function parseServerActionResult(raw: unknown): ChatMessageActionResult | undefined {
+  if (!raw || typeof raw !== 'object') return undefined;
+  const obj = raw as Record<string, unknown>;
+  if (typeof obj.type === 'string' && obj.data != null) return raw as ChatMessageActionResult;
+  // 서버 GET 응답의 raw 형태 — 고유 필드로 타입 감지, 나머지는 change
+  if ('dayPlans' in obj) return { type: 'itinerary', data: obj as unknown as DoneItinerary };
+  if ('cancelledAt' in obj) return { type: 'cancel', data: obj as unknown as DoneCancel };
+  if ('totalPrice' in obj) return { type: 'reservation', data: obj as unknown as DoneReservation };
+  return { type: 'change', data: obj as unknown as DoneChange };
+}
+
 export type SendChatMessageDone = {
   userMessage: ChatMessage;
   assistantMessage: ChatMessage;

--- a/api/chatMessages.ts
+++ b/api/chatMessages.ts
@@ -62,19 +62,40 @@ export type DoneChange = {
   adultCount: number;
   childCount: number;
   childAges: number[];
+  destinations?: { city: string; start_date: string; end_date: string }[];
   updatedAt: string;
 };
 
-export type DoneReservation = {
+export type AccommodationDetail = {
+  name: string;
+  rooms: number;
+  guests: number;
+  check_in: string;
+  check_out: string;
+};
+
+export type FlightDetail = {
+  airline: string;
+  departure: string;
+  arrival: string;
+  departing_at: string;
+  arriving_at: string;
+  stops: number;
+};
+
+type ReservationBase = {
   reservationId: string;
-  type: string;
-  status: string;
-  bookingUrl: string;
-  detail: Record<string, unknown>;
-  totalPrice: number;
+  status: 'confirmed' | 'changed' | 'cancelled';
+  bookingUrl?: string;
+  externalRefId?: string;
+  totalPrice: number | null;
   currency: string;
   reservedAt: string;
 };
+
+export type DoneReservation =
+  | (ReservationBase & { type: 'accommodation'; detail: AccommodationDetail })
+  | (ReservationBase & { type: 'flight'; detail: FlightDetail });
 
 export type DoneCancel = {
   reservationId: string;
@@ -173,12 +194,14 @@ const handleSseMessage = (message: string, handlers: ChatMessageStreamHandlers):
   }
 
   if (normalizedEvent === 'chunk') {
-    handlers.onChunk?.(JSON.parse(data) as SendChatMessageChunk);
+    const chunk = JSON.parse(data) as SendChatMessageChunk;
+    handlers.onChunk?.(chunk);
     return false;
   }
 
   if (normalizedEvent === 'done') {
-    handlers.onDone?.(JSON.parse(data) as SendChatMessageDone);
+    const done = JSON.parse(data) as SendChatMessageDone;
+    handlers.onDone?.(done);
     return true;
   }
 
@@ -203,7 +226,8 @@ const sendChatMessage = async (
   });
 
   if (!response.ok) {
-    throw new ChatMessageStreamError(response.status, await response.text());
+    const errorBody = await response.text();
+    throw new ChatMessageStreamError(response.status, errorBody);
   }
 
   return response;

--- a/api/chatRooms.ts
+++ b/api/chatRooms.ts
@@ -32,10 +32,14 @@ type ChatRoomDetail = {
   updatedAt: string;
 };
 
+type TripDestinationRequest = {
+  city: string;
+  start_date: string;
+  end_date: string;
+};
+
 type CreateChatRoomRequest = {
-  destination: string;
-  startDate: string;
-  endDate: string;
+  destinations: TripDestinationRequest[];
   budget?: number;
   adultCount: number;
   childCount: number;

--- a/api/itineraries.ts
+++ b/api/itineraries.ts
@@ -6,7 +6,7 @@ type Itinerary = {
   itineraryId: string;
   name: string;
   status: 'draft' | 'completed';
-  destination: string;
+  destinations: TripDestination[];
   totalDays: number;
   startDate: string;
 };

--- a/api/itineraries.ts
+++ b/api/itineraries.ts
@@ -15,6 +15,12 @@ type GetItinerariesResponse = {
   itineraries: Itinerary[];
 };
 
+type TripDestination = {
+  city: string;
+  start_date: string;
+  end_date: string;
+};
+
 export type DayPlanItem = {
   index: number;
   plan_name: string;
@@ -23,8 +29,6 @@ export type DayPlanItem = {
   note: string;
   cost?: DayPlanCost | null;
   status: string;
-  /** @deprecated Use cost instead. */
-  price?: number | null;
 };
 
 export type DayPlanCost = {
@@ -37,7 +41,7 @@ export type ItineraryDetail = {
   itineraryId: string;
   name: string;
   status: 'draft' | 'completed';
-  destination: string;
+  destinations: TripDestination[];
   budget: number | null;
   adultCount: number;
   childCount: number;
@@ -56,8 +60,7 @@ export const getItineraries = (token: string) =>
   });
 
 type UpdateItineraryRequest = {
-  startDate?: string;
-  endDate?: string;
+  destinations?: TripDestination[];
   budget?: number | null;
   adultCount?: number;
   childCount?: number;
@@ -87,7 +90,7 @@ type DayPlanItemInput = {
   time: string;
   place: string;
   note?: string;
-  price?: number | null;
+  cost?: DayPlanCost | null;
 };
 
 type UpdateDayPlansRequest = {
@@ -131,8 +134,6 @@ type LogDayPlanItem = {
   note: string;
   cost?: DayPlanCost | null;
   status: string;
-  /** @deprecated Use cost instead. */
-  price?: number | null;
 };
 
 type ItineraryLog = {

--- a/api/reservations.ts
+++ b/api/reservations.ts
@@ -4,16 +4,17 @@ const BASE = '/api/v1/reservations';
 
 type FlightDetail = {
   airline: string;
-  flight_no: string;
-  departure: { airport: string; datetime: string };
-  arrival: { airport: string; datetime: string };
-  seat_class: string;
-  passengers: { name: string; passport: string }[];
+  flight_no?: string;
+  departure: string;
+  arrival: string;
+  departing_at: string;
+  arriving_at: string;
+  stops: number;
 };
 
 type AccommodationDetail = {
-  hotel_name: string;
-  room_type: string;
+  name: string;
+  rooms: number;
   check_in: string;
   check_out: string;
   guests: number;
@@ -33,15 +34,13 @@ type CreateReservationRequest =
   | (ReservationBaseRequest & { type: 'flight'; detail: FlightDetail })
   | (ReservationBaseRequest & { type: 'accommodation'; detail: AccommodationDetail });
 
-type Reservation = {
+type ReservationBase = {
   reservationId: string;
   itineraryId: string;
-  type: 'flight' | 'accommodation';
   status: 'confirmed' | 'changed' | 'cancelled';
   bookedBy: 'user' | 'ai';
   bookingUrl: string | null;
   externalRefId: string | null;
-  detail: FlightDetail | AccommodationDetail;
   totalPrice: number | null;
   currency: string | null;
   reservedAt: string;
@@ -49,6 +48,10 @@ type Reservation = {
   createdAt: string;
   updatedAt: string;
 };
+
+type Reservation =
+  | (ReservationBase & { type: 'flight'; detail: FlightDetail })
+  | (ReservationBase & { type: 'accommodation'; detail: AccommodationDetail });
 
 type ReservationsParams = {
   type?: 'flight' | 'accommodation';

--- a/components/ChatActionResultCard.tsx
+++ b/components/ChatActionResultCard.tsx
@@ -57,7 +57,9 @@ function ItineraryDetail({ itinerary }: { itinerary: DoneItinerary }) {
             plans.map((plan, index) => (
               <View key={`${date}-${plan.index ?? index}`} style={styles.planRow}>
                 <View style={styles.planMainRow}>
-                  <Text style={[styles.planMain, { color: colors.textTitle }]}>
+                  <Text
+                    style={[styles.planMain, { color: colors.textTitle }]}
+                  >
                     {plan.time} · {plan.plan_name}
                   </Text>
                   {plan.cost ? (
@@ -219,15 +221,14 @@ const styles = StyleSheet.create({
     gap: 2,
   },
   planMainRow: {
-    alignItems: 'flex-start',
+    alignItems: 'baseline',
     flexDirection: 'row',
     gap: 8,
-    justifyContent: 'space-between',
   },
   planMain: {
     ...Typography['body-md'],
-    lineHeight: undefined,
     flex: 1,
+    minWidth: 0,
   },
   costText: {
     ...Typography['caption'],

--- a/components/ChatActionResultCard.tsx
+++ b/components/ChatActionResultCard.tsx
@@ -3,15 +3,30 @@ import { Pressable, StyleSheet, Text, View } from 'react-native';
 import { useTheme } from '@/hooks/useTheme';
 import { BorderRadius, Elevation, Typography } from '@/constants/theme';
 import { ChatMessageActionResult, DoneItinerary } from '@/api/chatMessages';
+import { formatKoreanDateTime } from '@/utils/dateTime';
 import IcChevronDown from '@/assets/icons/ic_chevron_down.svg';
 
 type Props = {
   result: ChatMessageActionResult;
 };
 
-function formatCurrency(value: number, currency = 'KRW') {
+function formatCurrency(value: number | null | undefined, currency = 'KRW') {
+  if (value == null) return '가격 미정';
   if (currency === 'KRW') return `${Math.round(value).toLocaleString('ko-KR')}원`;
   return `${value.toLocaleString()} ${currency}`;
+}
+
+function formatReservationType(type: string) {
+  if (type === 'flight') return '항공';
+  if (type === 'accommodation') return '숙소';
+  return type;
+}
+
+function formatReservationStatus(status: string) {
+  if (status === 'confirmed') return '확정';
+  if (status === 'changed') return '변경';
+  if (status === 'cancelled') return '취소';
+  return status;
 }
 
 function getTitle(result: ChatMessageActionResult) {
@@ -30,9 +45,9 @@ function getSummary(result: ChatMessageActionResult) {
     return `${result.data.startDate} ~ ${result.data.endDate} · 예산 ${formatCurrency(result.data.budget)}`;
   }
   if (result.type === 'reservation') {
-    return `${result.data.type} · ${result.data.status} · ${formatCurrency(result.data.totalPrice, result.data.currency)}`;
+    return `${formatReservationType(result.data.type)} · ${formatReservationStatus(result.data.status)} · ${formatCurrency(result.data.totalPrice, result.data.currency)}`;
   }
-  return `${result.data.status} · ${result.data.cancelledAt}`;
+  return `${formatReservationStatus(result.data.status)} · ${formatKoreanDateTime(result.data.cancelledAt)}`;
 }
 
 function ItineraryDetail({ itinerary }: { itinerary: DoneItinerary }) {
@@ -98,32 +113,59 @@ function ResultDetail({ result }: { result: ChatMessageActionResult }) {
   }
 
   if (result.type === 'change') {
+    const { startDate, endDate, totalDays, budget, adultCount, childCount, childAges, destinations } = result.data;
+    const destinationText = destinations?.map((d) => d.city).join(', ') ?? '-';
+    const childrenText =
+      childCount === 0
+        ? '없음'
+        : childAges?.length
+          ? `${childCount}명 (만 ${childAges.join(', ')}세)`
+          : `${childCount}명`;
+
     return (
       <View style={styles.detail}>
-        <KeyValueRow label="기간" value={`${result.data.startDate} ~ ${result.data.endDate}`} />
-        <KeyValueRow label="총 일수" value={`${result.data.totalDays}일`} />
-        <KeyValueRow label="예산" value={formatCurrency(result.data.budget)} />
-        <KeyValueRow label="인원" value={`성인 ${result.data.adultCount}명 · 아동 ${result.data.childCount}명`} />
+        <KeyValueRow label="여행지" value={destinationText} />
+        <KeyValueRow label="기간" value={`${startDate} ~ ${endDate}`} />
+        <KeyValueRow label="총 일수" value={`${totalDays}일`} />
+        <KeyValueRow label="예산" value={formatCurrency(budget)} />
+        <KeyValueRow label="성인" value={`${adultCount}명`} />
+        <KeyValueRow label="아동" value={childrenText} />
       </View>
     );
   }
 
   if (result.type === 'reservation') {
+    const { type, status, externalRefId, detail, totalPrice, currency } = result.data;
     return (
       <View style={styles.detail}>
-        <KeyValueRow label="유형" value={result.data.type} />
-        <KeyValueRow label="상태" value={result.data.status} />
-        <KeyValueRow label="금액" value={formatCurrency(result.data.totalPrice, result.data.currency)} />
-        <KeyValueRow label="예약 시간" value={result.data.reservedAt} />
+        <KeyValueRow label="유형" value={formatReservationType(type)} />
+        <KeyValueRow label="상태" value={formatReservationStatus(status)} />
+        {externalRefId ? <KeyValueRow label="예약번호" value={externalRefId} /> : null}
+        {type === 'accommodation' && (
+          <>
+            <KeyValueRow label="숙소명" value={detail.name} />
+            <KeyValueRow label="체크인" value={detail.check_in} />
+            <KeyValueRow label="체크아웃" value={detail.check_out} />
+            <KeyValueRow label="객실/인원" value={`${detail.rooms}실 · ${detail.guests}명`} />
+          </>
+        )}
+        {type === 'flight' && (
+          <>
+            <KeyValueRow label="항공사" value={detail.airline} />
+            <KeyValueRow label="출발" value={`${detail.departure} · ${formatKoreanDateTime(detail.departing_at)}`} />
+            <KeyValueRow label="도착" value={`${detail.arrival} · ${formatKoreanDateTime(detail.arriving_at)}`} />
+            <KeyValueRow label="경유" value={detail.stops === 0 ? '직항' : `${detail.stops}회`} />
+          </>
+        )}
+        <KeyValueRow label="금액" value={formatCurrency(totalPrice, currency)} />
       </View>
     );
   }
 
   return (
     <View style={styles.detail}>
-      <KeyValueRow label="예약 ID" value={result.data.reservationId} />
-      <KeyValueRow label="상태" value={result.data.status} />
-      <KeyValueRow label="취소 시간" value={result.data.cancelledAt} />
+      <KeyValueRow label="상태" value={formatReservationStatus(result.data.status)} />
+      <KeyValueRow label="취소 시간" value={formatKoreanDateTime(result.data.cancelledAt)} />
     </View>
   );
 }

--- a/components/ChatBubble.tsx
+++ b/components/ChatBubble.tsx
@@ -11,9 +11,10 @@ type Props = {
   variant: Variant;
   message: string;
   timestamp: string;
+  hideTimestamp?: boolean;
 };
 
-export function ChatBubble({ variant, message, timestamp }: Props) {
+export function ChatBubble({ variant, message, timestamp, hideTimestamp = false }: Props) {
   const { colors, scheme } = useTheme();
 
   const isUser = variant === 'user';
@@ -50,7 +51,9 @@ export function ChatBubble({ variant, message, timestamp }: Props) {
         <Text style={[styles.message, { color: colors.textTitle }]}>{message}</Text>
       </View>
 
-      <Text style={[styles.timestamp, { color: colors.textCaption }]}>{timestamp}</Text>
+      {!hideTimestamp && (
+        <Text style={[styles.timestamp, { color: colors.textCaption }]}>{timestamp}</Text>
+      )}
     </View>
   );
 }

--- a/components/ReservationCard.tsx
+++ b/components/ReservationCard.tsx
@@ -32,7 +32,7 @@ type FlightProps = CommonProps & {
   type: 'flight';
   departureCode: string;
   arrivalCode: string;
-  flightNumber: string;
+  flightNumber?: string;
   duration: string;
   departureTime: string;
   arrivalTime: string;
@@ -100,7 +100,9 @@ function CardBody({
             <Text style={[styles.caption, { color: captionColor }]}>{props.departureTime}</Text>
           </View>
           <View style={styles.flightCenter}>
-            <Text style={[styles.label, { color: captionColor }]}>{props.flightNumber}</Text>
+            {props.flightNumber ? (
+              <Text style={[styles.label, { color: captionColor }]}>{props.flightNumber}</Text>
+            ) : null}
             <View style={styles.flightArrowRow}>
               <View style={[styles.flightLine, { backgroundColor: captionColor }]} />
               <View style={[styles.flightArrowHead, { borderLeftColor: captionColor }]} />

--- a/components/TypeMessageWindow.tsx
+++ b/components/TypeMessageWindow.tsx
@@ -7,13 +7,14 @@ import { ChatSendButton } from '@/components/ChatSendButton';
 type Props = {
   onSend: (message: string) => void;
   onFocus?: () => void;
+  disabled?: boolean;
 };
 
-export function TypeMessageWindow({ onSend, onFocus }: Props) {
+export function TypeMessageWindow({ onSend, onFocus, disabled = false }: Props) {
   const { colors } = useTheme();
   const [text, setText] = useState('');
 
-  const isActive = text.trim().length > 0;
+  const isActive = text.trim().length > 0 && !disabled;
 
   const handleSend = () => {
     if (!isActive) return;
@@ -42,6 +43,7 @@ export function TypeMessageWindow({ onSend, onFocus }: Props) {
         value={text}
         onChangeText={setText}
         onFocus={onFocus}
+        editable
         returnKeyType="send"
         onSubmitEditing={handleSend}
         blurOnSubmit={false}

--- a/components/ui/BottomNavigation.tsx
+++ b/components/ui/BottomNavigation.tsx
@@ -72,7 +72,10 @@ export function BottomNavigation() {
           <Pressable
             key={route}
             style={styles.tab}
-            onPress={() => router.navigate(route as any)}
+            onPress={() => {
+              if (pathname === route) return;
+              router.replace(route as any);
+            }}
           >
             {({ pressed }) => (
               <View style={[styles.iconWrapper, pressed && { backgroundColor: colors.pressOverlay }]}>

--- a/components/ui/TripInfoBottomSheet.tsx
+++ b/components/ui/TripInfoBottomSheet.tsx
@@ -16,6 +16,7 @@ import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { BorderRadius, Elevation, Typography } from '@/constants/theme';
 import { useTheme } from '@/hooks/useTheme';
 import IcChevronDown from '@/assets/icons/ic_chevron_down.svg';
+import IcDelete from '@/assets/icons/ic_delete.svg';
 import IcPlan from '@/assets/icons/ic_plan.svg';
 import IcSearch from '@/assets/icons/ic_search.svg';
 
@@ -36,12 +37,24 @@ const AGE_OPTIONS = [
   '만 12세',
 ] as const;
 const MAX_PEOPLE_COUNT = 15;
+const MAX_DESTINATION_COUNT = 3;
 type AgeOption = (typeof AGE_OPTIONS)[number];
 
-export type TripInfo = {
+export type TripDestination = {
   destination: string;
   startDate: Date;
   endDate: Date;
+};
+
+type TripDestinationDraft = {
+  destination: string;
+  selectedDestination: string;
+  startDate: Date | null;
+  endDate: Date | null;
+};
+
+export type TripInfo = {
+  destinations: TripDestination[];
   adults: number;
   children: number;
   childAges: AgeOption[];
@@ -100,6 +113,12 @@ function isSameDay(a: Date, b: Date): boolean {
   );
 }
 
+function compareDateOnly(a: Date, b: Date): number {
+  const aTime = new Date(a.getFullYear(), a.getMonth(), a.getDate()).getTime();
+  const bTime = new Date(b.getFullYear(), b.getMonth(), b.getDate()).getTime();
+  return aTime - bTime;
+}
+
 function isBetween(date: Date, start: Date, end: Date): boolean {
   const dateTime = new Date(date.getFullYear(), date.getMonth(), date.getDate()).getTime();
   const startTime = new Date(start.getFullYear(), start.getMonth(), start.getDate()).getTime();
@@ -115,6 +134,27 @@ function normalizeBudget(value?: number): string {
   return value ? String(value) : '';
 }
 
+function createEmptyDestination(): TripDestinationDraft {
+  return {
+    destination: '',
+    selectedDestination: '',
+    startDate: null,
+    endDate: null,
+  };
+}
+
+function normalizeDestinations(values?: (TripDestinationDraft | TripDestination)[]): TripDestinationDraft[] {
+  const destinations = values
+    ?.map(value => ({
+      destination: value.destination.trim(),
+      selectedDestination: ('selectedDestination' in value ? value.selectedDestination.trim() : '') || value.destination.trim(),
+      startDate: value.startDate,
+      endDate: value.endDate,
+    }))
+    .filter(value => value.destination || value.startDate || value.endDate) ?? [];
+  return destinations.length > 0 ? destinations.slice(0, MAX_DESTINATION_COUNT) : [createEmptyDestination()];
+}
+
 function isSameDateValue(a: Date | null | undefined, b: Date | null | undefined): boolean {
   if (!a && !b) return true;
   if (!a || !b) return false;
@@ -124,6 +164,18 @@ function isSameDateValue(a: Date | null | undefined, b: Date | null | undefined)
 function areSameAges(a: (AgeOption | '')[], b: (AgeOption | '')[]): boolean {
   if (a.length !== b.length) return false;
   return a.every((value, index) => value === b[index]);
+}
+
+function areSameDestinations(a: TripDestinationDraft[], b: TripDestinationDraft[]): boolean {
+  const normalizedA = normalizeDestinations(a);
+  const normalizedB = normalizeDestinations(b);
+  if (normalizedA.length !== normalizedB.length) return false;
+  return normalizedA.every((value, index) => (
+    value.destination.trim() === normalizedB[index].destination.trim() &&
+    value.selectedDestination.trim() === normalizedB[index].selectedDestination.trim() &&
+    isSameDateValue(value.startDate, normalizedB[index].startDate) &&
+    isSameDateValue(value.endDate, normalizedB[index].endDate)
+  ));
 }
 
 function Calendar({ startDate, endDate, month, onDayPress, onPrevMonth, onNextMonth }: CalendarProps) {
@@ -288,7 +340,7 @@ export function TripInfoBottomSheet({ visible, mode, initialValues, roomName, on
   const insets = useSafeAreaInsets();
   const { height: screenHeight } = useWindowDimensions();
   const scrollViewRef = useRef<ScrollView>(null);
-  const destinationInputRef = useRef<TextInput>(null);
+  const destinationInputRefs = useRef<(TextInput | null)[]>([]);
 
   const SNAP_HALF = useMemo(() => screenHeight * 0.60, [screenHeight]);
   const SNAP_FULL = useMemo(() => screenHeight * 0.92, [screenHeight]);
@@ -300,20 +352,18 @@ export function TripInfoBottomSheet({ visible, mode, initialValues, roomName, on
   const onCloseRef = useRef(onClose);
   onCloseRef.current = onClose;
 
-  const [destination, setDestination] = useState('');
-  const [startDate, setStartDate] = useState<Date | null>(null);
-  const [endDate, setEndDate] = useState<Date | null>(null);
+  const [destinations, setDestinations] = useState<TripDestinationDraft[]>([createEmptyDestination()]);
   const [adults, setAdults] = useState(1);
   const [children, setChildren] = useState(0);
   const [childAges, setChildAges] = useState<(AgeOption | '')[]>([]);
   const [budget, setBudget] = useState('');
-  const [calendarExpanded, setCalendarExpanded] = useState(false);
+  const [activeCalendarIndex, setActiveCalendarIndex] = useState<number | null>(null);
   const [peopleExpanded, setPeopleExpanded] = useState(false);
   const [activeAgeDropdown, setActiveAgeDropdown] = useState<number | null>(null);
   const [calendarMonth, setCalendarMonth] = useState(new Date());
   const [keyboardHeight, setKeyboardHeight] = useState(0);
   const [budgetFocused, setBudgetFocused] = useState(false);
-  const [destinationFocused, setDestinationFocused] = useState(false);
+  const [focusedDestinationIndex, setFocusedDestinationIndex] = useState<number | null>(null);
   const [placePredictions, setPlacePredictions] = useState<PlacePrediction[]>([]);
   const [placesLoading, setPlacesLoading] = useState(false);
 
@@ -346,29 +396,27 @@ export function TripInfoBottomSheet({ visible, mode, initialValues, roomName, on
     if (!visible) return;
 
     const nextChildren = initialValues?.children ?? 0;
-    setDestination(initialValues?.destination ?? '');
-    setStartDate(initialValues?.startDate ?? null);
-    setEndDate(initialValues?.endDate ?? null);
+    setDestinations(normalizeDestinations(initialValues?.destinations));
     setAdults(initialValues?.adults ?? 1);
     setChildren(nextChildren);
     setChildAges(normalizeAges(nextChildren, initialValues?.childAges));
     setBudget(initialValues?.budget ? String(initialValues.budget) : '');
-    setCalendarExpanded(false);
+    setActiveCalendarIndex(null);
     setPeopleExpanded(false);
     setActiveAgeDropdown(null);
-    setCalendarMonth(initialValues?.startDate ?? new Date());
-    setDestinationFocused(false);
+    setCalendarMonth(initialValues?.destinations?.[0]?.startDate ?? new Date());
+    setFocusedDestinationIndex(null);
     setPlacePredictions([]);
   }, [visible, initialValues]);
 
   useEffect(() => {
-    if (!visible || mode !== 'create' || !destinationFocused) {
+    if (!visible || focusedDestinationIndex === null) {
       setPlacesLoading(false);
       setPlacePredictions([]);
       return;
     }
 
-    const query = destination.trim();
+    const query = destinations[focusedDestinationIndex]?.destination.trim() ?? '';
     if (!GOOGLE_MAPS_API_KEY || query.length < 2) {
       setPlacesLoading(false);
       setPlacePredictions([]);
@@ -406,7 +454,7 @@ export function TripInfoBottomSheet({ visible, mode, initialValues, roomName, on
       controller.abort();
       clearTimeout(timerId);
     };
-  }, [destination, destinationFocused, mode, visible]);
+  }, [destinations, focusedDestinationIndex, visible]);
 
   const handleClose = useCallback(() => {
     onCloseRef.current();
@@ -495,57 +543,117 @@ export function TripInfoBottomSheet({ visible, mode, initialValues, roomName, on
 
   const allChildAgesFilled =
     children === 0 || (childAges.length === children && childAges.every(age => age !== ''));
+  const completedDestinations = destinations
+    .map(value => ({
+      destination: value.destination.trim(),
+      selectedDestination: value.selectedDestination.trim(),
+      startDate: value.startDate,
+      endDate: value.endDate,
+    }))
+    .filter((value): value is TripDestination & { selectedDestination: string } => (
+      value.destination !== '' &&
+      value.selectedDestination === value.destination &&
+      value.startDate !== null &&
+      value.endDate !== null
+    ));
+  const initialDestinations = normalizeDestinations(initialValues?.destinations);
   const initialChildren = initialValues?.children ?? 0;
   const initialChildAges = normalizeAges(initialChildren, initialValues?.childAges);
   const hasChanges =
     mode === 'create' ||
-    destination.trim() !== (initialValues?.destination ?? '').trim() ||
-    !isSameDateValue(startDate, initialValues?.startDate ?? null) ||
-    !isSameDateValue(endDate, initialValues?.endDate ?? null) ||
+    !areSameDestinations(destinations, initialDestinations) ||
     adults !== (initialValues?.adults ?? 1) ||
     children !== initialChildren ||
     !areSameAges(childAges, initialChildAges) ||
     budget !== normalizeBudget(initialValues?.budget);
-  const isValid =
-    destination.trim() !== '' &&
-    startDate !== null &&
-    endDate !== null &&
-    adults >= 1 &&
-    allChildAgesFilled &&
-    Number(budget) > 0 &&
-    hasChanges;
+  const validationMessage = (() => {
+    const emptyDestinationIndex = destinations.findIndex(value => value.destination.trim() === '');
+    if (emptyDestinationIndex >= 0) return `여행지${emptyDestinationIndex + 1}을 입력해주세요.`;
 
-  const dateLabel =
-    startDate && endDate
-      ? `${formatDate(startDate)} ~ ${formatDate(endDate)}`
-      : startDate
-        ? `${formatDate(startDate)} ~ 종료일 선택`
-        : '날짜를 선택해주세요';
+    const unselectedDestinationIndex = destinations.findIndex(value => (
+      value.selectedDestination.trim() !== value.destination.trim()
+    ));
+    if (unselectedDestinationIndex >= 0) return `여행지${unselectedDestinationIndex + 1}을 검색 결과에서 선택해주세요.`;
+
+    const emptyDateIndex = destinations.findIndex(value => !value.startDate || !value.endDate);
+    if (emptyDateIndex >= 0) return `여행지${emptyDateIndex + 1}의 날짜를 선택해주세요.`;
+
+    for (let index = 1; index < completedDestinations.length; index += 1) {
+      const previous = completedDestinations[index - 1];
+      const current = completedDestinations[index];
+      const dateDiff = compareDateOnly(current.startDate, previous.endDate);
+
+      if (dateDiff > 0) {
+        return `여행지${index} 종료일과 여행지${index + 1} 시작일 사이에 빈 날짜가 있어요.`;
+      }
+
+      if (dateDiff < 0) {
+        return `여행지${index}과 여행지${index + 1}의 날짜가 겹쳐요.`;
+      }
+    }
+
+    if (!allChildAgesFilled) return '아동 나이를 모두 선택해주세요.';
+    if (Number(budget) <= 0) return '예산을 입력해주세요.';
+    if (!hasChanges) return '변경된 내용이 없습니다.';
+
+    return '';
+  })();
+  const isValid = validationMessage === '';
+
   const peopleLabel = `성인 ${adults}명${children > 0 ? `, 아동 ${children}명` : ''}`;
   const buttonLabel = mode === 'create' ? '채팅방 생성하기' : '수정하기';
   const footerBottom = Math.max(insets.bottom, 16);
   const contentBottomPadding = budgetFocused ? keyboardHeight + footerBottom + 24 : 24;
 
-  const handleDayPress = (day: Date) => {
-    if (!startDate || endDate) {
-      setStartDate(day);
-      setEndDate(null);
+  const getDateLabel = (destination: TripDestinationDraft) => {
+    if (destination.startDate && destination.endDate) {
+      return `${formatDate(destination.startDate)} ~ ${formatDate(destination.endDate)}`;
+    }
+
+    if (destination.startDate) {
+      return `${formatDate(destination.startDate)} ~ 종료일 선택`;
+    }
+
+    return '날짜를 선택해주세요';
+  };
+
+  const handleDayPress = (index: number, day: Date) => {
+    const selectedDestination = destinations[index];
+    if (!selectedDestination) return;
+
+    if (!selectedDestination.startDate || selectedDestination.endDate) {
+      setDestinations(prev => prev.map((destination, destinationIndex) => (
+        destinationIndex === index
+          ? { ...destination, startDate: day, endDate: null }
+          : destination
+      )));
       return;
     }
 
-    if (isSameDay(day, startDate)) {
-      setStartDate(null);
+    if (isSameDay(day, selectedDestination.startDate)) {
+      setDestinations(prev => prev.map((destination, destinationIndex) => (
+        destinationIndex === index
+          ? { ...destination, startDate: null, endDate: null }
+          : destination
+      )));
       return;
     }
 
-    if (day < startDate) {
-      setStartDate(day);
-      setEndDate(null);
+    if (day < selectedDestination.startDate) {
+      setDestinations(prev => prev.map((destination, destinationIndex) => (
+        destinationIndex === index
+          ? { ...destination, startDate: day, endDate: null }
+          : destination
+      )));
       return;
     }
 
-    setEndDate(day);
-    setCalendarExpanded(false);
+    setDestinations(prev => prev.map((destination, destinationIndex) => (
+      destinationIndex === index
+        ? { ...destination, endDate: day }
+        : destination
+    )));
+    setActiveCalendarIndex(null);
   };
 
   const updateChildren = (count: number) => {
@@ -555,13 +663,58 @@ export function TripInfoBottomSheet({ visible, mode, initialValues, roomName, on
     if (nextChildren === 0) setActiveAgeDropdown(null);
   };
 
+  const updateDestination = (index: number, value: string) => {
+    setDestinations(prev => prev.map((destination, destinationIndex) => (
+      destinationIndex === index
+        ? { ...destination, destination: value, selectedDestination: '' }
+        : destination
+    )));
+  };
+
+  const selectDestination = (index: number, value: string) => {
+    setDestinations(prev => prev.map((destination, destinationIndex) => (
+      destinationIndex === index
+        ? { ...destination, destination: value, selectedDestination: value }
+        : destination
+    )));
+  };
+
+  const addDestination = () => {
+    if (destinations.length >= MAX_DESTINATION_COUNT) return;
+
+    setDestinations(prev => [...prev, createEmptyDestination()]);
+    requestAnimationFrame(() => {
+      const nextIndex = destinations.length;
+      destinationInputRefs.current[nextIndex]?.focus();
+    });
+  };
+
+  const removeDestination = (index: number) => {
+    if (destinations.length <= 1) return;
+
+    setDestinations(prev => prev.filter((_, destinationIndex) => destinationIndex !== index));
+    setActiveCalendarIndex(current => {
+      if (current === null) return null;
+      if (current === index) return null;
+      return current > index ? current - 1 : current;
+    });
+    setFocusedDestinationIndex(current => {
+      if (current === null) return null;
+      if (current === index) return null;
+      return current > index ? current - 1 : current;
+    });
+    setPlacePredictions([]);
+  };
+
   const handleSubmit = () => {
-    if (!isValid || !startDate || !endDate) return;
+    if (!isValid) return;
 
     onSubmit({
-      destination: destination.trim(),
-      startDate,
-      endDate,
+      destinations: completedDestinations.map(destination => ({
+        destination: destination.destination,
+        startDate: destination.startDate,
+        endDate: destination.endDate,
+      })),
       adults,
       children,
       childAges: childAges as AgeOption[],
@@ -570,8 +723,10 @@ export function TripInfoBottomSheet({ visible, mode, initialValues, roomName, on
   };
 
   const handleSelectPlace = (place: PlacePrediction) => {
-    setDestination(place.description);
-    setDestinationFocused(false);
+    if (focusedDestinationIndex !== null) {
+      selectDestination(focusedDestinationIndex, place.description);
+    }
+    setFocusedDestinationIndex(null);
     setPlacePredictions([]);
     Keyboard.dismiss();
   };
@@ -609,103 +764,140 @@ export function TripInfoBottomSheet({ visible, mode, initialValues, roomName, on
               ) : null}
             </View>
             <View style={styles.fieldGroup}>
-              <Text style={[styles.fieldLabel, { color: colors.textSub }]}>여행지</Text>
-              <View style={[styles.inputBox, { backgroundColor: colors.cardBg, borderColor: colors.divider }, Elevation[scheme][4]]}>
-                <TextInput
-                    ref={destinationInputRef}
-                    value={destination}
-                    onChangeText={setDestination}
-                    onFocus={() => setDestinationFocused(true)}
-                    editable={mode === 'create'}
-                    placeholder="여행지를 입력해주세요"
-                    placeholderTextColor={colors.textDisabled}
-                    style={[styles.textInput, { color: mode === 'create' ? colors.textTitle : colors.textDisabled }]}
-                  />
-                  <Pressable
-                    onPress={() => {
-                      if (mode === 'create') destinationInputRef.current?.focus();
-                    }}
-                    style={styles.inputIconButton}
-                    hitSlop={8}
-                  >
-                    <IcSearch
-                      width={20}
-                      height={20}
-                      color={mode === 'create' && destination ? colors.textTitle : colors.textCaption}
-                    />
-                  </Pressable>
-              </View>
-              {mode === 'create' && destinationFocused && (placesLoading || placePredictions.length > 0) ? (
-                <View style={[styles.placePanel, { backgroundColor: colors.cardBg, borderColor: colors.divider }, Elevation[scheme][4]]}>
-                  {placesLoading ? (
-                    <Text style={[styles.placeMetaText, { color: colors.textCaption }]}>검색 중</Text>
-                  ) : (
-                    placePredictions.map((place, index) => (
+              <View style={styles.destinationList}>
+                {destinations.map((destination, index) => (
+                  <View key={index} style={styles.destinationItem}>
+                    <View style={styles.destinationHeader}>
+                      <Text style={[styles.fieldLabel, { color: colors.textSub }]}>여행지{index + 1}</Text>
+                      {destinations.length > 1 ? (
+                        <Pressable
+                          onPress={() => removeDestination(index)}
+                          style={styles.destinationDeleteButton}
+                          hitSlop={8}
+                        >
+                          {({ pressed }) => (
+                            <>
+                              <IcDelete width={18} height={18} color={colors.textCaption} />
+                              {pressed && (
+                                <View style={[StyleSheet.absoluteFill, { backgroundColor: colors.pressOverlay, borderRadius: BorderRadius.full }]} />
+                              )}
+                            </>
+                          )}
+                        </Pressable>
+                      ) : null}
+                    </View>
+                    <View style={[styles.inputBox, { backgroundColor: colors.cardBg, borderColor: colors.divider }, Elevation[scheme][4]]}>
+                      <TextInput
+                        ref={(input) => {
+                          destinationInputRefs.current[index] = input;
+                        }}
+                        value={destination.destination}
+                        onChangeText={(value) => updateDestination(index, value)}
+                        onFocus={() => setFocusedDestinationIndex(index)}
+                        placeholder={`여행지${index + 1}을 입력해주세요`}
+                        placeholderTextColor={colors.textDisabled}
+                        style={[styles.textInput, { color: colors.textTitle }]}
+                      />
                       <Pressable
-                        key={place.place_id}
-                        onPress={() => handleSelectPlace(place)}
-                        style={[
-                          styles.placeOption,
-                          index < placePredictions.length - 1 && { borderBottomColor: colors.divider, borderBottomWidth: 1 },
-                        ]}
+                        onPress={() => destinationInputRefs.current[index]?.focus()}
+                        style={styles.inputIconButton}
+                        hitSlop={8}
                       >
-                        {({ pressed }) => (
-                          <>
-                            <Text style={[styles.placeMainText, { color: colors.textTitle }]} numberOfLines={1}>
-                              {place.structured_formatting?.main_text ?? place.description}
-                            </Text>
-                            {place.structured_formatting?.secondary_text ? (
-                              <Text style={[styles.placeSubText, { color: colors.textCaption }]} numberOfLines={1}>
-                                {place.structured_formatting.secondary_text}
-                              </Text>
-                            ) : null}
-                            {pressed && (
-                              <View style={[StyleSheet.absoluteFill, { backgroundColor: colors.pressOverlay }]} />
-                            )}
-                          </>
-                        )}
+                        <IcSearch
+                          width={20}
+                          height={20}
+                          color={destination.destination ? colors.textTitle : colors.textCaption}
+                        />
                       </Pressable>
-                    ))
-                  )}
-                </View>
-              ) : null}
-            </View>
-
-            <View style={styles.fieldGroup}>
-              <Text style={[styles.fieldLabel, { color: colors.textSub }]}>날짜</Text>
-              <Pressable
-                onPress={() => {
-                  Keyboard.dismiss();
-                  setDestinationFocused(false);
-                  setPlacePredictions([]);
-                  setCalendarExpanded(value => !value);
-                  setPeopleExpanded(false);
-                  setActiveAgeDropdown(null);
-                }}
-                style={[styles.inputBox, { backgroundColor: colors.cardBg, borderColor: colors.divider }, Elevation[scheme][4]]}
-              >
-                {({ pressed }) => (
-                  <>
-                    <Text style={[styles.inputValue, { color: startDate ? colors.textTitle : colors.textDisabled }]}>
-                      {dateLabel}
-                    </Text>
-                    <IcPlan width={20} height={20} color={startDate ? colors.textTitle : colors.textCaption} />
-                    {pressed && (
-                      <View style={[StyleSheet.absoluteFill, { backgroundColor: colors.pressOverlay, borderRadius: BorderRadius.lg }]} />
+                    </View>
+                    {focusedDestinationIndex === index && (placesLoading || placePredictions.length > 0) ? (
+                      <View style={[styles.placePanel, { backgroundColor: colors.cardBg, borderColor: colors.divider }, Elevation[scheme][4]]}>
+                        {placesLoading ? (
+                          <Text style={[styles.placeMetaText, { color: colors.textCaption }]}>검색 중</Text>
+                        ) : (
+                          placePredictions.map((place, placeIndex) => (
+                            <Pressable
+                              key={place.place_id}
+                              onPress={() => handleSelectPlace(place)}
+                              style={[
+                                styles.placeOption,
+                                placeIndex < placePredictions.length - 1 && { borderBottomColor: colors.divider, borderBottomWidth: 1 },
+                              ]}
+                            >
+                              {({ pressed }) => (
+                                <>
+                                  <Text style={[styles.placeMainText, { color: colors.textTitle }]} numberOfLines={1}>
+                                    {place.structured_formatting?.main_text ?? place.description}
+                                  </Text>
+                                  {place.structured_formatting?.secondary_text ? (
+                                    <Text style={[styles.placeSubText, { color: colors.textCaption }]} numberOfLines={1}>
+                                      {place.structured_formatting.secondary_text}
+                                    </Text>
+                                  ) : null}
+                                  {pressed && (
+                                    <View style={[StyleSheet.absoluteFill, { backgroundColor: colors.pressOverlay }]} />
+                                  )}
+                                </>
+                              )}
+                            </Pressable>
+                          ))
+                        )}
+                      </View>
+                    ) : null}
+                    <Pressable
+                      onPress={() => {
+                        Keyboard.dismiss();
+                        setFocusedDestinationIndex(null);
+                        setPlacePredictions([]);
+                        setActiveCalendarIndex(value => value === index ? null : index);
+                        setCalendarMonth(destination.startDate ?? new Date());
+                        setPeopleExpanded(false);
+                        setActiveAgeDropdown(null);
+                      }}
+                      style={[styles.inputBox, { backgroundColor: colors.cardBg, borderColor: colors.divider }, Elevation[scheme][4]]}
+                    >
+                      {({ pressed }) => (
+                        <>
+                          <Text style={[styles.inputValue, { color: destination.startDate ? colors.textTitle : colors.textDisabled }]}>
+                            {getDateLabel(destination)}
+                          </Text>
+                          <IcPlan width={20} height={20} color={destination.startDate ? colors.textTitle : colors.textCaption} />
+                          {pressed && (
+                            <View style={[StyleSheet.absoluteFill, { backgroundColor: colors.pressOverlay, borderRadius: BorderRadius.lg }]} />
+                          )}
+                        </>
+                      )}
+                    </Pressable>
+                    {activeCalendarIndex === index && (
+                      <Calendar
+                        startDate={destination.startDate}
+                        endDate={destination.endDate}
+                        month={calendarMonth}
+                        onDayPress={(day) => handleDayPress(index, day)}
+                        onPrevMonth={() => setCalendarMonth(value => new Date(value.getFullYear(), value.getMonth() - 1, 1))}
+                        onNextMonth={() => setCalendarMonth(value => new Date(value.getFullYear(), value.getMonth() + 1, 1))}
+                      />
                     )}
-                  </>
-                )}
-              </Pressable>
-              {calendarExpanded && (
-                <Calendar
-                  startDate={startDate}
-                  endDate={endDate}
-                  month={calendarMonth}
-                  onDayPress={handleDayPress}
-                  onPrevMonth={() => setCalendarMonth(value => new Date(value.getFullYear(), value.getMonth() - 1, 1))}
-                  onNextMonth={() => setCalendarMonth(value => new Date(value.getFullYear(), value.getMonth() + 1, 1))}
-                />
-              )}
+                  </View>
+                ))}
+              </View>
+              {destinations.length < MAX_DESTINATION_COUNT ? (
+                <Pressable
+                  onPress={addDestination}
+                  style={[styles.addDestinationButton, { backgroundColor: colors.primaryLight }]}
+                >
+                  {({ pressed }) => (
+                    <>
+                      <Text style={[styles.addDestinationText, { color: scheme === 'light' ? colors.cardBg : colors.textTitle }]}>
+                        + 여행지 추가
+                      </Text>
+                      {pressed && (
+                        <View style={[StyleSheet.absoluteFill, { backgroundColor: colors.pressOverlay, borderRadius: BorderRadius.lg }]} />
+                      )}
+                    </>
+                  )}
+                </Pressable>
+              ) : null}
             </View>
 
             <View style={styles.fieldGroup}>
@@ -713,10 +905,10 @@ export function TripInfoBottomSheet({ visible, mode, initialValues, roomName, on
               <Pressable
                 onPress={() => {
                   Keyboard.dismiss();
-                  setDestinationFocused(false);
+                  setFocusedDestinationIndex(null);
                   setPlacePredictions([]);
                   setPeopleExpanded(value => !value);
-                  setCalendarExpanded(false);
+                  setActiveCalendarIndex(null);
                   setActiveAgeDropdown(null);
                 }}
                 style={[styles.inputBox, { backgroundColor: colors.cardBg, borderColor: colors.divider }, Elevation[scheme][4]]}
@@ -833,6 +1025,11 @@ export function TripInfoBottomSheet({ visible, mode, initialValues, roomName, on
             </View>
 
             <View style={[styles.footer, { paddingBottom: footerBottom }]}>
+              {validationMessage ? (
+                <Text style={[styles.validationText, { color: colors.danger }]}>
+                  * {validationMessage}
+                </Text>
+              ) : null}
               <Pressable
                 onPress={handleSubmit}
                 disabled={!isValid}
@@ -914,6 +1111,36 @@ const styles = StyleSheet.create({
   },
   fieldLabel: {
     ...Typography['heading-sm'],
+  },
+  destinationHeader: {
+    alignItems: 'center',
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+  },
+  destinationDeleteButton: {
+    alignItems: 'center',
+    borderRadius: BorderRadius.full,
+    height: 28,
+    justifyContent: 'center',
+    overflow: 'hidden',
+    width: 28,
+  },
+  destinationList: {
+    gap: 10,
+  },
+  destinationItem: {
+    gap: 8,
+  },
+  addDestinationButton: {
+    alignItems: 'center',
+    borderRadius: BorderRadius.lg,
+    height: 46,
+    justifyContent: 'center',
+    overflow: 'hidden',
+  },
+  addDestinationText: {
+    ...Typography['body-md'],
+    fontFamily: 'Pretendard-Bold',
   },
   inputBox: {
     alignItems: 'center',
@@ -1175,6 +1402,11 @@ const styles = StyleSheet.create({
   footer: {
     alignItems: 'center',
     paddingTop: 0,
+  },
+  validationText: {
+    ...Typography['body-sm'],
+    alignSelf: 'stretch',
+    marginBottom: 10,
   },
   primaryButton: {
     alignItems: 'center',

--- a/components/ui/TripInfoBottomSheet.tsx
+++ b/components/ui/TripInfoBottomSheet.tsx
@@ -74,6 +74,7 @@ type CalendarProps = {
   startDate: Date | null;
   endDate: Date | null;
   month: Date;
+  minSelectableDate: Date;
   onDayPress: (day: Date) => void;
   onPrevMonth: () => void;
   onNextMonth: () => void;
@@ -117,6 +118,11 @@ function compareDateOnly(a: Date, b: Date): number {
   const aTime = new Date(a.getFullYear(), a.getMonth(), a.getDate()).getTime();
   const bTime = new Date(b.getFullYear(), b.getMonth(), b.getDate()).getTime();
   return aTime - bTime;
+}
+
+function getTodayDateOnly(): Date {
+  const today = new Date();
+  return new Date(today.getFullYear(), today.getMonth(), today.getDate());
 }
 
 function isBetween(date: Date, start: Date, end: Date): boolean {
@@ -178,7 +184,7 @@ function areSameDestinations(a: TripDestinationDraft[], b: TripDestinationDraft[
   ));
 }
 
-function Calendar({ startDate, endDate, month, onDayPress, onPrevMonth, onNextMonth }: CalendarProps) {
+function Calendar({ startDate, endDate, month, minSelectableDate, onDayPress, onPrevMonth, onNextMonth }: CalendarProps) {
   const { colors, scheme } = useTheme();
   const year = month.getFullYear();
   const mon = month.getMonth();
@@ -245,6 +251,7 @@ function Calendar({ startDate, endDate, month, onDayPress, onPrevMonth, onNextMo
             const isEnd = !!endDate && isSameDay(day, endDate);
             const inRange = !!startDate && !!endDate && isBetween(day, startDate, endDate);
             const isSelected = isStart || isEnd;
+            const isDisabled = compareDateOnly(day, minSelectableDate) < 0 && !isSelected;
             const isFirstRangeDay =
               inRange &&
               !!startDate &&
@@ -257,6 +264,7 @@ function Calendar({ startDate, endDate, month, onDayPress, onPrevMonth, onNextMo
             return (
               <Pressable
                 key={dayIndex}
+                disabled={isDisabled}
                 onPress={() => onDayPress(day)}
                 style={styles.calendarCell}
               >
@@ -276,10 +284,15 @@ function Calendar({ startDate, endDate, month, onDayPress, onPrevMonth, onNextMo
                       style={[
                         styles.calendarDay,
                         isSelected && { backgroundColor: colors.primary },
-                        pressed && !isSelected && { backgroundColor: colors.pressOverlay },
+                        pressed && !isSelected && !isDisabled && { backgroundColor: colors.pressOverlay },
                       ]}
                     >
-                      <Text style={[styles.calendarDayText, { color: isSelected ? colors.pageBg : colors.textTitle }]}>
+                      <Text
+                        style={[
+                          styles.calendarDayText,
+                          { color: isSelected ? colors.pageBg : isDisabled ? colors.textDisabled : colors.textTitle },
+                        ]}
+                      >
                         {day.getDate()}
                       </Text>
                     </View>
@@ -604,6 +617,7 @@ export function TripInfoBottomSheet({ visible, mode, initialValues, roomName, on
   const buttonLabel = mode === 'create' ? '채팅방 생성하기' : '수정하기';
   const footerBottom = Math.max(insets.bottom, 16);
   const contentBottomPadding = budgetFocused ? keyboardHeight + footerBottom + 24 : 24;
+  const minSelectableDate = useMemo(() => getTodayDateOnly(), []);
 
   const getDateLabel = (destination: TripDestinationDraft) => {
     if (destination.startDate && destination.endDate) {
@@ -618,6 +632,8 @@ export function TripInfoBottomSheet({ visible, mode, initialValues, roomName, on
   };
 
   const handleDayPress = (index: number, day: Date) => {
+    if (compareDateOnly(day, minSelectableDate) < 0) return;
+
     const selectedDestination = destinations[index];
     if (!selectedDestination) return;
 
@@ -873,6 +889,7 @@ export function TripInfoBottomSheet({ visible, mode, initialValues, roomName, on
                         startDate={destination.startDate}
                         endDate={destination.endDate}
                         month={calendarMonth}
+                        minSelectableDate={minSelectableDate}
                         onDayPress={(day) => handleDayPress(index, day)}
                         onPrevMonth={() => setCalendarMonth(value => new Date(value.getFullYear(), value.getMonth() - 1, 1))}
                         onNextMonth={() => setCalendarMonth(value => new Date(value.getFullYear(), value.getMonth() + 1, 1))}

--- a/constants/queryKeys.ts
+++ b/constants/queryKeys.ts
@@ -9,6 +9,7 @@ export const queryKeys = {
     all: ['chatRooms'] as const,
     detail: (roomId: string) => ['chatRooms', roomId] as const,
     messages: (roomId: string) => ['chatRooms', roomId, 'messages'] as const,
+    pending: (roomId: string) => ['chatRooms', roomId, 'pending'] as const,
   },
 
   reservations: {
@@ -43,5 +44,6 @@ export const GC_TIMES = {
   chatRooms: {
     detail: 1000 * 60 * 5,
     messages: 1000 * 60 * 3,
+    pending: 1000 * 60 * 30,
   },
 } as const;

--- a/constants/queryKeys.ts
+++ b/constants/queryKeys.ts
@@ -9,8 +9,6 @@ export const queryKeys = {
     all: ['chatRooms'] as const,
     detail: (roomId: string) => ['chatRooms', roomId] as const,
     messages: (roomId: string) => ['chatRooms', roomId, 'messages'] as const,
-    // TODO: 백엔드 GET 채팅 메시지 응답에 assistant actionResult가 포함되면 제거.
-    messageResults: (roomId: string) => ['chatRooms', roomId, 'messageResults'] as const,
   },
 
   reservations: {

--- a/screens/ChangeLogDetailScreen.tsx
+++ b/screens/ChangeLogDetailScreen.tsx
@@ -12,6 +12,7 @@ import { BOTTOM_NAVIGATION } from '@/constants/layout';
 import { BorderRadius, Typography } from '@/constants/theme';
 import { getErrorMessage } from '@/utils/getErrorMessage';
 import { getDisplayCost } from '@/utils/itineraryDisplay';
+import { formatTripDestinationCities } from '@/utils/tripInfo';
 import { ItineraryOverviewCard2BeforeEdit } from '@/components/ItineraryOverviewCard2BeforeEdit';
 import { PlanDetailItem } from '@/components/PlanDetailItem';
 
@@ -103,13 +104,14 @@ export function ChangeLogDetailScreen({ itineraryId, logId }: Props) {
   if (!itinerary || !log) return null;
 
   const headerDate = `${itinerary.startDate.replace(/-/g, '.')} - ${itinerary.endDate.replace(/-/g, '.')}`;
+  const headerLocation = formatTripDestinationCities(itinerary.destinations);
 
   return (
     <View style={[styles.container, { backgroundColor: colors.pageBg }]}>
       <ItineraryOverviewCard2BeforeEdit
         title={itinerary.name}
         date={headerDate}
-        location={itinerary.destination}
+        location={headerLocation}
         dayCount={log.totalDays}
         selectedDay={selectedDay}
         onDayPress={setSelectedDay}
@@ -134,7 +136,7 @@ export function ChangeLogDetailScreen({ itineraryId, logId }: Props) {
           <View style={styles.detailList}>
             {activeDayPlans.map((item, index) => {
               const { startTime, endTime } = splitTimeRange(item.time);
-              const { price, currency } = getDisplayCost(item.cost, item.price);
+              const { price, currency } = getDisplayCost(item.cost);
               return (
                 <PlanDetailItem
                   key={`day${selectedDay}-item${index}`}

--- a/screens/ChatRoomScreen.tsx
+++ b/screens/ChatRoomScreen.tsx
@@ -518,7 +518,7 @@ export function ChatRoomScreen({ chatId }: Props) {
           {pendingChat?.isSending && pendingChat.assistantMessage?.content && showResultPreparing && (
             <ChatBubble
               variant="ai"
-              message={`여행 일정을 표로 정리하는 중입니다${'.'.repeat(thinkingDotCount)}`}
+              message={`보기 좋게 정리하는 중입니다${'.'.repeat(thinkingDotCount)}`}
               timestamp={formatTimestamp(new Date().toISOString())}
               hideTimestamp
             />

--- a/screens/ChatRoomScreen.tsx
+++ b/screens/ChatRoomScreen.tsx
@@ -9,14 +9,14 @@ import Toast from 'react-native-toast-message';
 import { useTheme } from '@/hooks/useTheme';
 import { useApi } from '@/hooks/useApi';
 import { getErrorMessage, getDeleteChatRoomErrorMessage } from '@/utils/getErrorMessage';
-import { formatDateOnly } from '@/utils/dateOnly';
-import { toTripInfoInitialValues } from '@/utils/tripInfo';
+import { formatTripDestinations, toTripInfoInitialValues } from '@/utils/tripInfo';
 import { queryKeys, STALE_TIMES, GC_TIMES } from '@/constants/queryKeys';
 import { AlertMessages } from '@/constants/alerts';
 import { getChatRooms, getChatRoom, deleteChatRoom, updateChatRoomName } from '@/api/chatRooms';
 import {
   getChatMessages,
   sendChatMessageStream,
+  parseServerActionResult,
   ChatMessage,
   ChatMessageActionResult,
   ChatMessagesResponse,
@@ -37,8 +37,6 @@ import { BOTTOM_NAVIGATION, CHAT_HEADER_HEIGHT } from '@/constants/layout';
 
 type Props = { chatId: string };
 type DisplayMessage = ChatMessage;
-// TODO: 백엔드 GET 채팅 메시지 응답에 assistant actionResult가 포함되면 제거.
-type MessageResultsCache = Record<string, ChatMessageActionResult>;
 
 
 function toActionResult(done: {
@@ -89,7 +87,7 @@ function mergeDoneItinerary(old: ItineraryDetail | undefined, itinerary: DoneIti
           place: plan.place,
           note: plan.note,
           status: plan.status,
-          price: plan.cost?.amount_krw ?? plan.cost?.amount ?? null,
+          cost: plan.cost ?? null,
         })),
       ]),
     ),
@@ -117,7 +115,6 @@ export function ChatRoomScreen({ chatId }: Props) {
   const [isSending, setIsSending] = useState(false);
   const [streamingMessages, setStreamingMessages] = useState<DisplayMessage[]>([]);
   const [confirmedLocalMessages, setConfirmedLocalMessages] = useState<DisplayMessage[]>([]);
-  const [messageItineraries, setMessageItineraries] = useState<Record<string, DoneItinerary>>({});
   const [thinkingDotCount, setThinkingDotCount] = useState(1);
   const [selectedChatId, setSelectedChatId] = useState(chatId);
   const deletedChatIdsRef = useRef(new Set<string>());
@@ -149,14 +146,6 @@ export function ChatRoomScreen({ chatId }: Props) {
     },
     enabled: !!roomData,
     staleTime: STALE_TIMES.chatRooms.messages,
-    gcTime: GC_TIMES.chatRooms.messages,
-  });
-
-  const { data: messageResults = {} } = useQuery({
-    queryKey: queryKeys.chatRooms.messageResults(chatId),
-    queryFn: () =>
-      queryClient.getQueryData<MessageResultsCache>(queryKeys.chatRooms.messageResults(chatId)) ?? {},
-    staleTime: Infinity,
     gcTime: GC_TIMES.chatRooms.messages,
   });
 
@@ -231,7 +220,6 @@ export function ChatRoomScreen({ chatId }: Props) {
       if (roomId !== chatId) {
         queryClient.removeQueries({ queryKey: queryKeys.chatRooms.detail(roomId) });
         queryClient.removeQueries({ queryKey: queryKeys.chatRooms.messages(roomId) });
-        queryClient.removeQueries({ queryKey: queryKeys.chatRooms.messageResults(roomId) });
       }
       queryClient.invalidateQueries({ queryKey: queryKeys.chatRooms.all });
       queryClient.invalidateQueries({ queryKey: queryKeys.itineraries.all });
@@ -276,8 +264,7 @@ export function ChatRoomScreen({ chatId }: Props) {
     mutationFn: ({ info, itineraryId }: { info: TripInfo; itineraryId: string }) =>
       authRequest((token) =>
         updateItinerary(token, itineraryId, {
-          startDate: formatDateOnly(info.startDate),
-          endDate: formatDateOnly(info.endDate),
+          destinations: formatTripDestinations(info.destinations),
           budget: info.budget * 10000,
           adultCount: info.adults,
           childCount: info.children,
@@ -339,23 +326,8 @@ export function ChatRoomScreen({ chatId }: Props) {
           },
           onDone: (done) => {
             const assistantMessage = attachDoneResultToAssistantMessage(done);
-            const assistantResult = assistantMessage.actionResult;
-
-            if (assistantResult) {
-              queryClient.setQueryData<MessageResultsCache>(
-                queryKeys.chatRooms.messageResults(chatId),
-                (old) => ({
-                  ...(old ?? {}),
-                  [done.assistantMessage.messageId]: assistantResult,
-                }),
-              );
-            }
 
             if (done.itinerary) {
-              setMessageItineraries((prev) => ({
-                ...prev,
-                [done.assistantMessage.messageId]: done.itinerary!,
-              }));
               queryClient.setQueryData<ItineraryDetail>(
                 queryKeys.itineraries.detail(done.itinerary.itineraryId),
                 (old) => mergeDoneItinerary(old, done.itinerary!),
@@ -432,12 +404,7 @@ export function ChatRoomScreen({ chatId }: Props) {
       .reverse()
       .map((message) => ({
         ...message,
-        actionResult:
-          message.actionResult ??
-          messageResults[message.messageId] ??
-          (messageItineraries[message.messageId]
-            ? { type: 'itinerary', data: messageItineraries[message.messageId] }
-            : undefined),
+        actionResult: parseServerActionResult(message.actionResult),
       }));
     const serverMessageIds = new Set(serverMessages.map((message) => message.messageId));
     const localConfirmedMessages = confirmedLocalMessages.filter(
@@ -445,7 +412,7 @@ export function ChatRoomScreen({ chatId }: Props) {
     );
 
     return [...serverMessages, ...localConfirmedMessages, ...streamingMessages];
-  }, [confirmedLocalMessages, messageItineraries, messageResults, messagesData, streamingMessages]);
+  }, [confirmedLocalMessages, messagesData, streamingMessages]);
 
   useEffect(() => {
     if (messagesLoading) return;
@@ -558,14 +525,21 @@ export function ChatRoomScreen({ chatId }: Props) {
           closeDrawerThen(() => setEditTripInfoVisible(true));
         }}
         onChatViewPlan={(id) => {
-          closeDrawerThen(() => {
-          // 캐시에서 itineraryId 조회 후 해당 일정으로 이동
-            const cached = queryClient.getQueryData<{ itineraryId?: string }>(
-              queryKeys.chatRooms.detail(String(id)),
-            );
-            if (cached?.itineraryId) {
-              router.push({ pathname: '/plan-list/[id]', params: { id: cached.itineraryId } });
-            } else {
+          closeDrawerThen(async () => {
+            try {
+              const room = await queryClient.fetchQuery({
+                queryKey: queryKeys.chatRooms.detail(String(id)),
+                queryFn: () => authRequest((token) => getChatRoom(token, String(id))),
+                staleTime: STALE_TIMES.chatRooms.detail,
+                gcTime: GC_TIMES.chatRooms.detail,
+              });
+              if (room.itineraryId) {
+                router.push({ pathname: '/plan-list/[id]', params: { id: room.itineraryId } });
+              } else {
+                router.navigate('/plan-list');
+              }
+            } catch (error) {
+              Toast.show({ type: 'error', text1: getErrorMessage(error) });
               router.navigate('/plan-list');
             }
           });

--- a/screens/ChatRoomScreen.tsx
+++ b/screens/ChatRoomScreen.tsx
@@ -10,6 +10,7 @@ import Toast from 'react-native-toast-message';
 import { useTheme } from '@/hooks/useTheme';
 import { useApi } from '@/hooks/useApi';
 import { getErrorMessage, getDeleteChatRoomErrorMessage } from '@/utils/getErrorMessage';
+import { formatKoreanTime } from '@/utils/dateTime';
 import { formatTripDestinations, toTripInfoInitialValues } from '@/utils/tripInfo';
 import { queryKeys, STALE_TIMES, GC_TIMES } from '@/constants/queryKeys';
 import { AlertMessages } from '@/constants/alerts';
@@ -67,12 +68,7 @@ function attachDoneResultToAssistantMessage(done: SendChatMessageDone): DisplayM
 }
 
 function formatTimestamp(isoString: string): string {
-  const date = new Date(isoString);
-  const hours = date.getHours();
-  const minutes = date.getMinutes();
-  const period = hours < 12 ? '오전' : '오후';
-  const displayHours = hours % 12 || 12;
-  return `${period} ${displayHours}:${String(minutes).padStart(2, '0')}`;
+  return formatKoreanTime(isoString);
 }
 
 function mergeDoneItinerary(old: ItineraryDetail | undefined, itinerary: DoneItinerary) {

--- a/screens/ChatRoomScreen.tsx
+++ b/screens/ChatRoomScreen.tsx
@@ -2,6 +2,7 @@ import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { ActivityIndicator, Keyboard, KeyboardAvoidingView, Platform, ScrollView, StyleSheet, Text, View } from 'react-native';
 import { useRouter } from 'expo-router';
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { useFocusEffect } from '@react-navigation/native';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { useAuth } from '@clerk/clerk-expo';
 import axios from 'axios';
@@ -106,6 +107,8 @@ export function ChatRoomScreen({ chatId }: Props) {
   const router = useRouter();
   const queryClient = useQueryClient();
   const scrollViewRef = useRef<ScrollView>(null);
+  const focusedRef = useRef(false);
+  const roomNameRef = useRef('채팅방');
   const insets = useSafeAreaInsets();
 
   const [drawerVisible, setDrawerVisible] = useState(false);
@@ -187,6 +190,22 @@ export function ChatRoomScreen({ chatId }: Props) {
     () => (itineraryDetail ? toTripInfoInitialValues(itineraryDetail) : undefined),
     [itineraryDetail],
   );
+
+  useFocusEffect(
+    useCallback(() => {
+      focusedRef.current = true;
+      return () => {
+        focusedRef.current = false;
+      };
+    }, []),
+  );
+
+  useEffect(() => {
+    roomNameRef.current =
+      roomData?.name ??
+      chatRoomsData?.rooms.find((room) => room.roomId === chatId)?.name ??
+      '채팅방';
+  }, [chatId, chatRoomsData, roomData]);
 
   useEffect(() => {
     if (!roomError) return;
@@ -379,6 +398,14 @@ export function ChatRoomScreen({ chatId }: Props) {
 
             if (done.reservation || done.cancel) {
               queryClient.invalidateQueries({ queryKey: queryKeys.reservations.all });
+            }
+
+            if (!focusedRef.current) {
+              Toast.show({
+                type: 'success',
+                text1: 'AI 응답이 완료되었습니다.',
+                text2: `${roomNameRef.current}에서 새 응답이 도착했습니다.`,
+              });
             }
           },
         });

--- a/screens/ChatRoomScreen.tsx
+++ b/screens/ChatRoomScreen.tsx
@@ -38,6 +38,11 @@ import { BOTTOM_NAVIGATION, CHAT_HEADER_HEIGHT } from '@/constants/layout';
 type Props = { chatId: string };
 type DisplayMessage = ChatMessage;
 
+type PendingChatState = {
+  isSending: boolean;
+  userMessage: ChatMessage;
+  assistantMessage?: ChatMessage;
+};
 
 function toActionResult(done: {
   itinerary?: SendChatMessageDone['itinerary'];
@@ -112,9 +117,6 @@ export function ChatRoomScreen({ chatId }: Props) {
     top: CHAT_HEADER_HEIGHT + insets.top - 8,
     right: 16,
   });
-  const [isSending, setIsSending] = useState(false);
-  const [streamingMessages, setStreamingMessages] = useState<DisplayMessage[]>([]);
-  const [confirmedLocalMessages, setConfirmedLocalMessages] = useState<DisplayMessage[]>([]);
   const [thinkingDotCount, setThinkingDotCount] = useState(1);
   const [selectedChatId, setSelectedChatId] = useState(chatId);
   const deletedChatIdsRef = useRef(new Set<string>());
@@ -147,6 +149,13 @@ export function ChatRoomScreen({ chatId }: Props) {
     enabled: !!roomData,
     staleTime: STALE_TIMES.chatRooms.messages,
     gcTime: GC_TIMES.chatRooms.messages,
+  });
+
+  const { data: pendingChat = null } = useQuery({
+    queryKey: queryKeys.chatRooms.pending(chatId),
+    queryFn: () => null as PendingChatState | null,
+    staleTime: Infinity,
+    gcTime: GC_TIMES.chatRooms.pending,
   });
 
   const { data: chatRoomsData } = useQuery({
@@ -194,10 +203,7 @@ export function ChatRoomScreen({ chatId }: Props) {
   }, [chatId, messagesError, roomData]);
 
   useEffect(() => {
-    const hasAssistantStreaming = streamingMessages.some(
-      (msg) => msg.role === 'assistant' && msg.content.length > 0,
-    );
-    if (!isSending || hasAssistantStreaming) {
+    if (!pendingChat?.isSending) {
       setThinkingDotCount(1);
       return;
     }
@@ -207,7 +213,7 @@ export function ChatRoomScreen({ chatId }: Props) {
     }, 450);
 
     return () => clearInterval(intervalId);
-  }, [isSending, streamingMessages]);
+  }, [pendingChat]);
 
   const deleteMutation = useMutation({
     mutationFn: (roomId: string) => authRequest((token) => deleteChatRoom(token, roomId)),
@@ -217,6 +223,7 @@ export function ChatRoomScreen({ chatId }: Props) {
         queryKeys.chatRooms.all,
         (old) => old ? { ...old, rooms: old.rooms.filter((room) => room.roomId !== roomId) } : old,
       );
+      queryClient.removeQueries({ queryKey: queryKeys.chatRooms.pending(roomId) });
       if (roomId !== chatId) {
         queryClient.removeQueries({ queryKey: queryKeys.chatRooms.detail(roomId) });
         queryClient.removeQueries({ queryKey: queryKeys.chatRooms.messages(roomId) });
@@ -283,18 +290,20 @@ export function ChatRoomScreen({ chatId }: Props) {
 
   const handleSend = useCallback(
     async (message: string) => {
-      if (isSending) return;
+      const pendingKey = queryKeys.chatRooms.pending(chatId);
+      const currentPending = queryClient.getQueryData<PendingChatState>(pendingKey);
+      if (currentPending?.isSending) return;
 
-      setIsSending(true);
       const now = new Date().toISOString();
-      setStreamingMessages([
-        {
+      queryClient.setQueryData<PendingChatState>(pendingKey, {
+        isSending: true,
+        userMessage: {
           messageId: '__pending_user',
           role: 'user',
           content: message,
           createdAt: now,
         },
-      ]);
+      });
 
       try {
         const token = await getToken();
@@ -302,25 +311,18 @@ export function ChatRoomScreen({ chatId }: Props) {
 
         await sendChatMessageStream(token, chatId, { content: message }, {
           onChunk: (chunk) => {
-            setStreamingMessages((prev) => {
-              const assistant = prev.find((msg) => msg.messageId === '__streaming_ai');
-              if (assistant) {
-                return prev.map((msg) =>
-                  msg.messageId === '__streaming_ai'
-                    ? { ...msg, content: msg.content + chunk.content }
-                    : msg,
-                );
-              }
-
-              return [
-                ...prev,
-                {
+            queryClient.setQueryData<PendingChatState>(pendingKey, (old) => {
+              if (!old) return old;
+              const assistantMessage = old.assistantMessage
+                ? { ...old.assistantMessage, content: old.assistantMessage.content + chunk.content }
+                : {
                   messageId: '__streaming_ai',
-                  role: 'assistant',
+                  role: 'assistant' as const,
                   content: chunk.content,
                   createdAt: new Date().toISOString(),
-                },
-              ];
+                };
+
+              return { ...old, assistantMessage };
             });
             setTimeout(() => scrollViewRef.current?.scrollToEnd({ animated: false }), 0);
           },
@@ -333,16 +335,6 @@ export function ChatRoomScreen({ chatId }: Props) {
                 (old) => mergeDoneItinerary(old, done.itinerary!),
               );
             }
-
-            setConfirmedLocalMessages((prev) => {
-              const nextMessages: DisplayMessage[] = [
-                done.userMessage,
-                assistantMessage,
-              ];
-              const nextIds = new Set(nextMessages.map((msg) => msg.messageId));
-              return [...prev.filter((msg) => !nextIds.has(msg.messageId)), ...nextMessages];
-            });
-            setStreamingMessages([]);
 
             queryClient.setQueryData<ChatMessagesResponse>(
               queryKeys.chatRooms.messages(chatId),
@@ -366,6 +358,7 @@ export function ChatRoomScreen({ chatId }: Props) {
                 };
               },
             );
+            queryClient.setQueryData<PendingChatState | null>(pendingKey, null);
 
             queryClient.invalidateQueries({ queryKey: queryKeys.chatRooms.messages(chatId) });
             queryClient.invalidateQueries({ queryKey: queryKeys.chatRooms.all });
@@ -390,13 +383,11 @@ export function ChatRoomScreen({ chatId }: Props) {
           },
         });
       } catch (e) {
-        setStreamingMessages([]);
+        queryClient.setQueryData<PendingChatState | null>(pendingKey, null);
         Toast.show({ type: 'error', text1: getErrorMessage(e) });
-      } finally {
-        setIsSending(false);
       }
     },
-    [chatId, getToken, isSending, queryClient],
+    [chatId, getToken, queryClient],
   );
 
   const displayMessages = useMemo(() => {
@@ -406,13 +397,12 @@ export function ChatRoomScreen({ chatId }: Props) {
         ...message,
         actionResult: parseServerActionResult(message.actionResult),
       }));
-    const serverMessageIds = new Set(serverMessages.map((message) => message.messageId));
-    const localConfirmedMessages = confirmedLocalMessages.filter(
-      (message) => !serverMessageIds.has(message.messageId),
-    );
+    const pendingMessages = pendingChat
+      ? [pendingChat.userMessage, pendingChat.assistantMessage].filter(Boolean) as DisplayMessage[]
+      : [];
 
-    return [...serverMessages, ...localConfirmedMessages, ...streamingMessages];
-  }, [confirmedLocalMessages, messagesData, streamingMessages]);
+    return [...serverMessages, ...pendingMessages];
+  }, [messagesData, pendingChat]);
 
   useEffect(() => {
     if (messagesLoading) return;
@@ -478,10 +468,17 @@ export function ChatRoomScreen({ chatId }: Props) {
             ))
           )}
 
-          {isSending && !streamingMessages.some((msg) => msg.role === 'assistant' && msg.content.length > 0) && (
+          {pendingChat?.isSending && !pendingChat.assistantMessage?.content && (
             <ChatBubble
               variant="ai"
               message={`AI가 열심히 생각 중입니다${'.'.repeat(thinkingDotCount)}`}
+              timestamp={formatTimestamp(new Date().toISOString())}
+            />
+          )}
+          {pendingChat?.isSending && pendingChat.assistantMessage?.content && (
+            <ChatBubble
+              variant="ai"
+              message={`여행 일정을 표로 정리하는 중입니다${'.'.repeat(thinkingDotCount)}`}
               timestamp={formatTimestamp(new Date().toISOString())}
             />
           )}
@@ -490,6 +487,7 @@ export function ChatRoomScreen({ chatId }: Props) {
         <TypeMessageWindow
           onSend={handleSend}
           onFocus={() => scrollToLatestMessage(true)}
+          disabled={!!pendingChat?.isSending}
         />
       </KeyboardAvoidingView>
       <View style={{ height: bottomOffset }} />

--- a/screens/ChatRoomScreen.tsx
+++ b/screens/ChatRoomScreen.tsx
@@ -43,6 +43,7 @@ type PendingChatState = {
   isSending: boolean;
   userMessage: ChatMessage;
   assistantMessage?: ChatMessage;
+  lastChunkAt?: number;
 };
 
 function toActionResult(done: {
@@ -121,6 +122,7 @@ export function ChatRoomScreen({ chatId }: Props) {
     right: 16,
   });
   const [thinkingDotCount, setThinkingDotCount] = useState(1);
+  const [showResultPreparing, setShowResultPreparing] = useState(false);
   const [selectedChatId, setSelectedChatId] = useState(chatId);
   const deletedChatIdsRef = useRef(new Set<string>());
   const pendingDrawerActionRef = useRef<(() => void) | null>(null);
@@ -234,6 +236,20 @@ export function ChatRoomScreen({ chatId }: Props) {
     return () => clearInterval(intervalId);
   }, [pendingChat]);
 
+  useEffect(() => {
+    if (!pendingChat?.isSending || !pendingChat.assistantMessage?.content || !pendingChat.lastChunkAt) {
+      setShowResultPreparing(false);
+      return;
+    }
+
+    setShowResultPreparing(false);
+    const timerId = setTimeout(() => {
+      setShowResultPreparing(true);
+    }, 700);
+
+    return () => clearTimeout(timerId);
+  }, [pendingChat?.isSending, pendingChat?.assistantMessage?.content, pendingChat?.lastChunkAt]);
+
   const deleteMutation = useMutation({
     mutationFn: (roomId: string) => authRequest((token) => deleteChatRoom(token, roomId)),
     onSuccess: (_, roomId) => {
@@ -341,7 +357,7 @@ export function ChatRoomScreen({ chatId }: Props) {
                   createdAt: new Date().toISOString(),
                 };
 
-              return { ...old, assistantMessage };
+              return { ...old, assistantMessage, lastChunkAt: Date.now() };
             });
             setTimeout(() => scrollViewRef.current?.scrollToEnd({ animated: false }), 0);
           },
@@ -379,14 +395,10 @@ export function ChatRoomScreen({ chatId }: Props) {
             );
             queryClient.setQueryData<PendingChatState | null>(pendingKey, null);
 
-            queryClient.invalidateQueries({ queryKey: queryKeys.chatRooms.messages(chatId) });
-            queryClient.invalidateQueries({ queryKey: queryKeys.chatRooms.all });
+            queryClient.invalidateQueries({ queryKey: queryKeys.chatRooms.all, exact: true });
 
             if (done.itinerary) {
               queryClient.invalidateQueries({ queryKey: queryKeys.itineraries.all });
-              queryClient.invalidateQueries({
-                queryKey: queryKeys.itineraries.detail(done.itinerary.itineraryId),
-              });
             }
 
             if (done.change) {
@@ -500,13 +512,15 @@ export function ChatRoomScreen({ chatId }: Props) {
               variant="ai"
               message={`AI가 열심히 생각 중입니다${'.'.repeat(thinkingDotCount)}`}
               timestamp={formatTimestamp(new Date().toISOString())}
+              hideTimestamp
             />
           )}
-          {pendingChat?.isSending && pendingChat.assistantMessage?.content && (
+          {pendingChat?.isSending && pendingChat.assistantMessage?.content && showResultPreparing && (
             <ChatBubble
               variant="ai"
               message={`여행 일정을 표로 정리하는 중입니다${'.'.repeat(thinkingDotCount)}`}
               timestamp={formatTimestamp(new Date().toISOString())}
+              hideTimestamp
             />
           )}
         </ScrollView>

--- a/screens/HomeScreen.tsx
+++ b/screens/HomeScreen.tsx
@@ -176,6 +176,7 @@ export function HomeScreen() {
       );
       queryClient.removeQueries({ queryKey: queryKeys.chatRooms.detail(roomId) });
       queryClient.removeQueries({ queryKey: queryKeys.chatRooms.messages(roomId) });
+      queryClient.removeQueries({ queryKey: queryKeys.chatRooms.pending(roomId) });
       queryClient.invalidateQueries({ queryKey: queryKeys.chatRooms.all });
       queryClient.invalidateQueries({ queryKey: queryKeys.itineraries.all });
       setSelectedChatId(null);

--- a/screens/HomeScreen.tsx
+++ b/screens/HomeScreen.tsx
@@ -7,8 +7,7 @@ import Toast from 'react-native-toast-message';
 import { useTheme } from '@/hooks/useTheme';
 import { useApi } from '@/hooks/useApi';
 import { getErrorMessage, getDeleteChatRoomErrorMessage } from '@/utils/getErrorMessage';
-import { formatDateOnly } from '@/utils/dateOnly';
-import { toTripInfoInitialValues } from '@/utils/tripInfo';
+import { formatTripDestinations, toTripInfoInitialValues } from '@/utils/tripInfo';
 import { AlertMessages } from '@/constants/alerts';
 import { Header } from '@/components/ui/Header';
 import { HomeAIBanner } from '@/components/HomeAIBanner';
@@ -177,7 +176,6 @@ export function HomeScreen() {
       );
       queryClient.removeQueries({ queryKey: queryKeys.chatRooms.detail(roomId) });
       queryClient.removeQueries({ queryKey: queryKeys.chatRooms.messages(roomId) });
-      queryClient.removeQueries({ queryKey: queryKeys.chatRooms.messageResults(roomId) });
       queryClient.invalidateQueries({ queryKey: queryKeys.chatRooms.all });
       queryClient.invalidateQueries({ queryKey: queryKeys.itineraries.all });
       setSelectedChatId(null);
@@ -193,8 +191,7 @@ export function HomeScreen() {
     mutationFn: ({ info, itineraryId }: { info: TripInfo; itineraryId: string }) =>
       authRequest((token) =>
         updateItinerary(token, itineraryId, {
-          startDate: formatDateOnly(info.startDate),
-          endDate: formatDateOnly(info.endDate),
+          destinations: formatTripDestinations(info.destinations),
           budget: info.budget * 10000,
           adultCount: info.adults,
           childCount: info.children,

--- a/screens/NewChatScreen.tsx
+++ b/screens/NewChatScreen.tsx
@@ -7,8 +7,7 @@ import { useTheme } from '@/hooks/useTheme';
 import { useApi } from '@/hooks/useApi';
 import { Typography } from '@/constants/theme';
 import { getErrorMessage, getDeleteChatRoomErrorMessage } from '@/utils/getErrorMessage';
-import { formatDateOnly } from '@/utils/dateOnly';
-import { toTripInfoInitialValues } from '@/utils/tripInfo';
+import { formatTripDestinations, toTripInfoInitialValues } from '@/utils/tripInfo';
 import { queryKeys, STALE_TIMES, GC_TIMES } from '@/constants/queryKeys';
 import { AlertMessages } from '@/constants/alerts';
 import { getChatRooms, getChatRoom, createChatRoom, deleteChatRoom, updateChatRoomName } from '@/api/chatRooms';
@@ -100,7 +99,6 @@ export function NewChatScreen() {
       );
       queryClient.removeQueries({ queryKey: queryKeys.chatRooms.detail(roomId) });
       queryClient.removeQueries({ queryKey: queryKeys.chatRooms.messages(roomId) });
-      queryClient.removeQueries({ queryKey: queryKeys.chatRooms.messageResults(roomId) });
       queryClient.invalidateQueries({ queryKey: queryKeys.chatRooms.all });
       queryClient.invalidateQueries({ queryKey: queryKeys.itineraries.all });
       Toast.show({ type: 'success', text1: '채팅방이 삭제되었습니다.' });
@@ -136,8 +134,7 @@ export function NewChatScreen() {
     mutationFn: ({ info, itineraryId }: { info: TripInfo; itineraryId: string }) =>
       authRequest((token) =>
         updateItinerary(token, itineraryId, {
-          startDate: formatDateOnly(info.startDate),
-          endDate: formatDateOnly(info.endDate),
+          destinations: formatTripDestinations(info.destinations),
           budget: info.budget * 10000,
           adultCount: info.adults,
           childCount: info.children,
@@ -156,9 +153,7 @@ export function NewChatScreen() {
 
   const handleTripSubmit = (info: TripInfo) => {
     createMutation.mutate({
-      destination: info.destination,
-      startDate: formatDateOnly(info.startDate),
-      endDate: formatDateOnly(info.endDate),
+      destinations: formatTripDestinations(info.destinations),
       budget: info.budget * 10000,
       adultCount: info.adults,
       childCount: info.children,
@@ -224,14 +219,21 @@ export function NewChatScreen() {
           closeDrawerThen(() => setEditTripInfoVisible(true));
         }}
         onChatViewPlan={(chatId) => {
-          closeDrawerThen(() => {
-          // 캐시에서 itineraryId 조회 후 해당 일정으로 이동
-            const cached = queryClient.getQueryData<{ itineraryId?: string }>(
-              queryKeys.chatRooms.detail(String(chatId)),
-            );
-            if (cached?.itineraryId) {
-              router.push({ pathname: '/plan-list/[id]', params: { id: cached.itineraryId } });
-            } else {
+          closeDrawerThen(async () => {
+            try {
+              const room = await queryClient.fetchQuery({
+                queryKey: queryKeys.chatRooms.detail(String(chatId)),
+                queryFn: () => authRequest((token) => getChatRoom(token, String(chatId))),
+                staleTime: STALE_TIMES.chatRooms.detail,
+                gcTime: GC_TIMES.chatRooms.detail,
+              });
+              if (room.itineraryId) {
+                router.push({ pathname: '/plan-list/[id]', params: { id: room.itineraryId } });
+              } else {
+                router.navigate('/plan-list');
+              }
+            } catch (error) {
+              Toast.show({ type: 'error', text1: getErrorMessage(error) });
               router.navigate('/plan-list');
             }
           });

--- a/screens/NewChatScreen.tsx
+++ b/screens/NewChatScreen.tsx
@@ -99,6 +99,7 @@ export function NewChatScreen() {
       );
       queryClient.removeQueries({ queryKey: queryKeys.chatRooms.detail(roomId) });
       queryClient.removeQueries({ queryKey: queryKeys.chatRooms.messages(roomId) });
+      queryClient.removeQueries({ queryKey: queryKeys.chatRooms.pending(roomId) });
       queryClient.invalidateQueries({ queryKey: queryKeys.chatRooms.all });
       queryClient.invalidateQueries({ queryKey: queryKeys.itineraries.all });
       Toast.show({ type: 'success', text1: '채팅방이 삭제되었습니다.' });

--- a/screens/PlanListDetailEditScreen.tsx
+++ b/screens/PlanListDetailEditScreen.tsx
@@ -13,6 +13,7 @@ import { BOTTOM_NAVIGATION } from '@/constants/layout';
 import { BorderRadius, Typography } from '@/constants/theme';
 import { getErrorMessage } from '@/utils/getErrorMessage';
 import { getDisplayCost } from '@/utils/itineraryDisplay';
+import { formatTripDestinationCities } from '@/utils/tripInfo';
 import { ItineraryOverviewCard2Editing } from '@/components/ItineraryOverviewCard2Editing';
 import { PlanDetailEditItem, ScheduleItem } from '@/components/PlanDetailEditItem';
 
@@ -23,7 +24,7 @@ type DayPlanInput = {
   time: string;
   place: string;
   note?: string;
-  price?: number | null;
+  cost?: DayPlanCost | null;
 };
 
 function addDays(dateStr: string, days: number): string {
@@ -65,11 +66,10 @@ function toScheduleItem(
     place: string;
     note: string;
     cost?: DayPlanCost | null;
-    price?: number | null;
   },
 ): ScheduleItem {
   const { startTime, endTime } = splitTimeRange(item.time);
-  const { price } = getDisplayCost(item.cost, item.price);
+  const { price } = getDisplayCost(item.cost);
 
   return {
     id: `${dateKey}-${item.index}`,
@@ -84,12 +84,15 @@ function toScheduleItem(
 }
 
 function toDayPlanInput(item: ScheduleItem): DayPlanInput {
+  const cost = item.type === 'editable' && item.price != null
+    ? { amount: item.price, currency: 'KRW', amount_krw: null }
+    : null;
   return {
     plan_name: item.title,
     time: joinTimeRange(item.startTime, item.endTime),
     place: item.type === 'editable' ? (item.location ?? '') : '',
     note: item.type === 'editable' ? (item.memo ?? undefined) : undefined,
-    price: item.type === 'editable' ? (item.price ?? null) : null,
+    cost,
   };
 }
 
@@ -197,6 +200,7 @@ export function PlanListDetailEditScreen({ id }: Props) {
   if (!itinerary) return null;
 
   const headerDate = `${itinerary.startDate.replace(/-/g, '.')} - ${itinerary.endDate.replace(/-/g, '.')}`;
+  const headerLocation = formatTripDestinationCities(itinerary.destinations);
 
   return (
     <KeyboardAvoidingView
@@ -206,7 +210,7 @@ export function PlanListDetailEditScreen({ id }: Props) {
       <ItineraryOverviewCard2Editing
         title={itinerary.name}
         date={headerDate}
-        location={itinerary.destination}
+        location={headerLocation}
         dayCount={itinerary.totalDays}
         selectedDay={selectedDay}
         onDayPress={setSelectedDay}

--- a/screens/PlanListDetailScreen.tsx
+++ b/screens/PlanListDetailScreen.tsx
@@ -12,6 +12,7 @@ import { BOTTOM_NAVIGATION } from '@/constants/layout';
 import { BorderRadius, Typography } from '@/constants/theme';
 import { getErrorMessage } from '@/utils/getErrorMessage';
 import { getDisplayCost } from '@/utils/itineraryDisplay';
+import { formatTripDestinationCities } from '@/utils/tripInfo';
 import { ItineraryOverviewCard2BeforeEdit } from '@/components/ItineraryOverviewCard2BeforeEdit';
 import { PlanDetailItem } from '@/components/PlanDetailItem';
 
@@ -94,13 +95,14 @@ export function PlanListDetailScreen({ id }: Props) {
   if (!itinerary) return null;
 
   const headerDate = `${itinerary.startDate.replace(/-/g, '.')} - ${itinerary.endDate.replace(/-/g, '.')}`;
+  const headerLocation = formatTripDestinationCities(itinerary.destinations);
 
   return (
     <View style={[styles.container, { backgroundColor: colors.pageBg }]}>
       <ItineraryOverviewCard2BeforeEdit
         title={itinerary.name}
         date={headerDate}
-        location={itinerary.destination}
+        location={headerLocation}
         dayCount={itinerary.totalDays}
         selectedDay={selectedDay}
         onDayPress={setSelectedDay}
@@ -122,7 +124,7 @@ export function PlanListDetailScreen({ id }: Props) {
           <View style={styles.detailList}>
             {activeDayPlans.map((item, index) => {
               const { startTime, endTime } = splitTimeRange(item.time);
-              const { price, currency } = getDisplayCost(item.cost, item.price);
+              const { price, currency } = getDisplayCost(item.cost);
               return (
                 <PlanDetailItem
                   key={`day${selectedDay}-item${index}`}

--- a/screens/PlanListScreen.tsx
+++ b/screens/PlanListScreen.tsx
@@ -24,21 +24,6 @@ type Tab = 'itinerary' | 'reservation';
 type ResType = 'all' | 'flight' | 'accommodation';
 type ResStatus = 'all' | 'confirmed' | 'changed' | 'cancelled';
 
-type LocalFlightDetail = {
-  airline: string;
-  flight_no: string;
-  departure: { airport: string; datetime: string };
-  arrival: { airport: string; datetime: string };
-};
-
-type LocalAccommodationDetail = {
-  hotel_name: string;
-  room_type: string;
-  check_in: string;
-  check_out: string;
-  guests: number;
-};
-
 function formatDate(dateStr: string) {
   return dateStr.replace(/-/g, '.');
 }
@@ -230,33 +215,32 @@ export function PlanListScreen() {
                 };
 
                 if (r.type === 'flight') {
-                  const d = r.detail as LocalFlightDetail;
+                  const d = r.detail;
                   return (
                     <ReservationCard
                       key={r.reservationId}
                       type="flight"
-                      departureCode={d.departure.airport}
-                      arrivalCode={d.arrival.airport}
-                      flightNumber={d.flight_no}
-                      duration={calcFlightDuration(d.departure.datetime, d.arrival.datetime)}
-                      departureTime={formatTime(d.departure.datetime)}
-                      arrivalTime={formatTime(d.arrival.datetime)}
-                      date={formatDateShort(d.departure.datetime)}
+                      departureCode={d.departure}
+                      arrivalCode={d.arrival}
+                      duration={calcFlightDuration(d.departing_at, d.arriving_at)}
+                      departureTime={formatTime(d.departing_at)}
+                      arrivalTime={formatTime(d.arriving_at)}
+                      date={formatDateShort(d.departing_at)}
                       airline={d.airline}
                       {...common}
                     />
                   );
                 }
 
-                const d = r.detail as LocalAccommodationDetail;
+                const d = r.detail;
                 return (
                   <ReservationCard
                     key={r.reservationId}
                     type="lodging"
-                    hotelName={d.hotel_name}
+                    hotelName={d.name}
                     checkInDate={d.check_in}
                     checkOutDate={d.check_out}
-                    roomType={d.room_type}
+                    roomType={`${d.rooms}실`}
                     guests={d.guests}
                     {...common}
                   />

--- a/screens/PlanListScreen.tsx
+++ b/screens/PlanListScreen.tsx
@@ -13,6 +13,7 @@ import { queryKeys, STALE_TIMES } from '@/constants/queryKeys';
 import { BOTTOM_NAVIGATION } from '@/constants/layout';
 import { Typography } from '@/constants/theme';
 import { getErrorMessage } from '@/utils/getErrorMessage';
+import { formatTripDestinationCities } from '@/utils/tripInfo';
 import { TravelListTabBar } from '@/components/TravelListTabBar';
 import { TravelPlanCard } from '@/components/TravelPlanCard';
 import { ReservationCard } from '@/components/ReservationCard';
@@ -183,7 +184,7 @@ export function PlanListScreen() {
                 key={item.itineraryId}
                 title={item.name}
                 startDate={formatDate(item.startDate)}
-                destination={item.destination}
+                destination={formatTripDestinationCities(item.destinations)}
                 duration={formatDuration(item.totalDays)}
                 status={item.status === 'completed' ? 'completed' : 'upcoming'}
                 onPress={() =>

--- a/screens/PlanScreen.tsx
+++ b/screens/PlanScreen.tsx
@@ -22,7 +22,6 @@ type Itinerary = {
   itineraryId: string;
   name: string;
   status: 'draft' | 'completed';
-  destination: string;
   totalDays: number;
   startDate: string;
 };

--- a/utils/dateTime.ts
+++ b/utils/dateTime.ts
@@ -1,0 +1,104 @@
+const ISO_DATE_TIME_PATTERN =
+  /^(\d{4})-(\d{2})-(\d{2})T(\d{2}):(\d{2})(?::(\d{2})(?:\.\d+)?)?(Z|([+-])(\d{2}):(\d{2}))?$/;
+
+type DateTimeParts = {
+  year: number;
+  month: number;
+  day: number;
+  hour: number;
+  minute: number;
+};
+
+function isLeapYear(year: number) {
+  return year % 4 === 0 && (year % 100 !== 0 || year % 400 === 0);
+}
+
+function getDaysInMonth(year: number, month: number) {
+  if (month === 2) return isLeapYear(year) ? 29 : 28;
+  return [4, 6, 9, 11].includes(month) ? 30 : 31;
+}
+
+function addMinutes(parts: DateTimeParts, amount: number): DateTimeParts {
+  let { year, month, day, hour, minute } = parts;
+  minute += amount;
+
+  while (minute >= 60) {
+    minute -= 60;
+    hour += 1;
+  }
+
+  while (minute < 0) {
+    minute += 60;
+    hour -= 1;
+  }
+
+  while (hour >= 24) {
+    hour -= 24;
+    day += 1;
+
+    if (day > getDaysInMonth(year, month)) {
+      day = 1;
+      month += 1;
+
+      if (month > 12) {
+        month = 1;
+        year += 1;
+      }
+    }
+  }
+
+  while (hour < 0) {
+    hour += 24;
+    day -= 1;
+
+    if (day < 1) {
+      month -= 1;
+
+      if (month < 1) {
+        month = 12;
+        year -= 1;
+      }
+
+      day = getDaysInMonth(year, month);
+    }
+  }
+
+  return { year, month, day, hour, minute };
+}
+
+function parseIsoToKoreanParts(value: string): DateTimeParts | null {
+  const match = value.match(ISO_DATE_TIME_PATTERN);
+  if (!match) return null;
+
+  const [, year, month, day, hour, minute, , zone, sign, offsetHour = '0', offsetMinute = '0'] = match;
+  const parts = {
+    year: Number(year),
+    month: Number(month),
+    day: Number(day),
+    hour: Number(hour),
+    minute: Number(minute),
+  };
+
+  if (zone !== 'Z' && sign === '+' && offsetHour === '09' && offsetMinute === '00') {
+    return parts;
+  }
+
+  const sourceOffsetMinutes = zone === 'Z'
+    ? 0
+    : (sign === '-' ? -1 : 1) * (Number(offsetHour) * 60 + Number(offsetMinute));
+  return addMinutes(parts, 9 * 60 - sourceOffsetMinutes);
+}
+
+export function formatKoreanDateTime(value: string) {
+  const parts = parseIsoToKoreanParts(value);
+  if (!parts) return value;
+
+  return `${parts.year}년 ${parts.month}월 ${parts.day}일 ${String(parts.hour).padStart(2, '0')}:${String(parts.minute).padStart(2, '0')}`;
+}
+
+export function formatKoreanTime(value: string) {
+  const parts = parseIsoToKoreanParts(value);
+  if (!parts) return value;
+
+  return `${String(parts.hour).padStart(2, '0')}:${String(parts.minute).padStart(2, '0')}`;
+}

--- a/utils/itineraryDisplay.ts
+++ b/utils/itineraryDisplay.ts
@@ -7,12 +7,11 @@ export type DisplayCost = {
 
 export function getDisplayCost(
   cost?: DayPlanCost | null,
-  legacyPrice?: number | null,
 ): DisplayCost {
   if (cost) {
     if (cost.amount_krw != null) return { price: cost.amount_krw, currency: 'KRW' };
     return { price: cost.amount, currency: cost.currency };
   }
 
-  return legacyPrice == null ? {} : { price: legacyPrice, currency: 'KRW' };
+  return {};
 }

--- a/utils/tripInfo.ts
+++ b/utils/tripInfo.ts
@@ -1,15 +1,35 @@
 import { ItineraryDetail } from '@/api/itineraries';
-import { TripInfo } from '@/components/ui/TripInfoBottomSheet';
-import { parseDateOnly } from '@/utils/dateOnly';
+import { TripDestination, TripInfo } from '@/components/ui/TripInfoBottomSheet';
+import { formatDateOnly, parseDateOnly } from '@/utils/dateOnly';
+
+export type TripDestinationRequest = {
+  city: string;
+  start_date: string;
+  end_date: string;
+};
+
+export function formatTripDestinations(destinations: TripDestination[]): TripDestinationRequest[] {
+  return destinations.map((destination) => ({
+    city: destination.destination,
+    start_date: formatDateOnly(destination.startDate),
+    end_date: formatDateOnly(destination.endDate),
+  }));
+}
+
+export function formatTripDestinationCities(destinations: { city: string }[]): string {
+  return destinations.map((destination) => destination.city).filter(Boolean).join(', ');
+}
 
 export function toTripInfoInitialValues(detail: Pick<
   ItineraryDetail,
-  'destination' | 'startDate' | 'endDate' | 'budget' | 'adultCount' | 'childCount' | 'childAges'
+  'destinations' | 'budget' | 'adultCount' | 'childCount' | 'childAges'
 >): Partial<TripInfo> {
   return {
-    destination: detail.destination,
-    startDate: parseDateOnly(detail.startDate),
-    endDate: parseDateOnly(detail.endDate),
+    destinations: detail.destinations.map((destination) => ({
+      destination: destination.city,
+      startDate: parseDateOnly(destination.start_date),
+      endDate: parseDateOnly(destination.end_date),
+    })),
     budget: detail.budget != null ? Math.round(detail.budget / 10000) : undefined,
     adults: detail.adultCount,
     children: detail.childCount,


### PR DESCRIPTION
# 요약
다구간 여행지 도입으로 인한 여행 정보 입력 및 수정 UI를 개선합니다.
또한, 채팅방 관련 로직을 보완합니다.

# 연관 이슈 및 Close 할 이슈 작성
close #39

# Pull Request 체크리스트

- [x] 🔥 TripInfo에 다구간 여행지 UI 적용
- [x] 🔥 TripInfo에서 여행지 수정 가능하도록 변경
- [x] 🔥 여행지는 최대 3개까지만 등록 가능하도록 제한 → 현재는 임시로 3개 제한이며, 추후 최대 개수는 변경될 수 있음
- [x] 🔥 Chatrooms 내 `//TODO` 처리
- [x] 🔥 채팅방 AI 응답 요청 중 화면 이탈 후 재진입 시 Loading UI가 유지되도록 개선
  - 채팅방 ID별 pending 상태를 React Query cache로 관리
  - 사용자 메시지, AI 로딩 상태, 스트리밍 메시지를 pending cache에 저장
  - 화면을 벗어나도 진행 중 상태가 유지되도록 처리
  - chunk/response 수신 시 pending cache를 갱신하고, 응답 완료 시 최종 메시지를 messages cache에 반영
  - 응답 완료 시 pending cache를 정리하고, 앱 재실행 후에는 기존 message history 조회를 통해 최종 응답 메시지를 복원
- [x] 🔥 화면 이탈 상태에서 AI 응답 완료 시 Toast 알림 표시
   - 응답이 완료된 채팅방명을 Toast에 함께 표시
- [x] 🔥 AI 응답 완료 전 상태 표시 UI 보완
   - chunk 표시 이후 SSE done 응답 수신 전까지 `보기 좋게 정리하는 중입니다...` 버블 표시 → 마지막 chunk 이후 done이 700ms 이상 늦으면 표시. 짧은 일반 답변 시에는 잠깐 표시될 순 있음.
    - AI 응답 대기 및 정리 상태 버블에서는 시간 표시 숨김
- [x] 🔥 AI 응답 완료 후 캐시 갱신 로직 보완
   - SSE done 응답으로 메시지 및 일정 상세 캐시를 직접 갱신하여 중복 조회 제거
   - 채팅방 목록은 `aiSummary` 갱신을 위해 목록 캐시만 정확히 갱신
- [x] 🔥 백엔드 assistantMessage 부분에 저장되는 actionResult에서 itinerary말고도 change, reservation, cancel가 메시지 히스토리 조회 시 `components\ChatActionResultCard.tsx` 잘 적용되는지 확인
- [x] 🔥 예약 필드 response Detail 필드명 변경에 따른 업데이트
   - 공통: type, status, externalRefId, totalPrice, currency
   - accommodation detail: name, check_in, check_out, rooms, guests
   - flight detail: airline, departure, departing_at, arrival, arriving_at, stops
   - flightNumber는 현재 응답에 없으므로 optional 처리했고, 없으면 표시하지 않음
- [x] 🔥 `components/ui/TripInfoBottomSheet.tsx` 오늘 이전 날짜는 선택 불가능하게 막음.
   - 캘린더에서 오늘 이전 날짜 disabled 처리
   - handleDayPress에서도 과거 날짜 선택 방어
   - 기존 edit 데이터의 과거 선택값은 표시 유지

## TODO

- [x] 최종 결과물을 확인했는가?
- [x] 의미 있는 커밋 메시지를 작성했는가?